### PR TITLE
Support callbacks

### DIFF
--- a/lib/update-notifier.js
+++ b/lib/update-notifier.js
@@ -15,17 +15,29 @@ function UpdateNotifier(options) {
 		this.packageFile = require(path.resolve(path.dirname(module.parent.filename), options.packagePath || 'package'));
 	}
 
+	if (options.callback) {
+		this.hasCallback = true;
+	}
+
 	this.packageName = options.packageName || this.packageFile.name;
 	this.packageVersion = options.packageVersion || this.packageFile.version;
 	this.updateCheckInterval = typeof options.updateCheckInterval === 'number' ? options.updateCheckInterval : 1000 * 60 * 60 * 24; // 1 day
 	this.updateCheckTimeout = typeof options.updateCheckTimeout === 'number' ? options.updateCheckTimeout : 20000;                  // 20 secs
 	this.registryUrl = options.registryUrl || 'http://registry.npmjs.org/%s';
-	this.config = new Configstore('update-notifier-' + this.packageName, {
-		optOut: false
-	});
+	this.callback = options.callback || function() {};
+
+	if (!this.hasCallback) {
+		this.config = new Configstore('update-notifier-' + this.packageName, {
+			optOut: false
+		});
+	}
 }
 
 UpdateNotifier.prototype.check = function() {
+	if (this.hasCallback) {
+		return this.checkNpm(this.callback);
+	}
+
 	var cp;
 
 	if (this.config.get('optOut')) {

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,17 @@ A convenience method that will inform the user about an available update (see sc
 ### Settings
 
 
+#### callback
+
+Type: `function`  
+Default: `null`
+
+If provided, a callback function will be called,
+passed `(error[, update])`
+
+`update` is equal to `notifier.update`
+
+
 #### packagePath
 
 Type: `string`  

--- a/test/test-update-notifier.js
+++ b/test/test-update-notifier.js
@@ -5,21 +5,31 @@ var fs = require('fs');
 var updateNotifier = require('../lib/update-notifier');
 
 describe('updateNotifier', function() {
-	var settings = {
-		packageName: 'yeoman',
-		packageVersion: '0.9.3'
+	var generateSettings = function (options) {
+		options = options || {};
+		return {
+			packageName: options.packageName || 'generator-backbone',
+			packageVersion: options.packageVersion || '0.1.0',
+			callback: options.callback || null
+		};
 	};
 
-	var configstorePath = updateNotifier(settings).config.path;
+	var configstorePath = updateNotifier(generateSettings()).config.path;
 
 	afterEach(function() {
 		fs.unlinkSync(configstorePath);
 	});
 
 	it('should check for update', function(cb) {
-		updateNotifier(settings).checkNpm(function(error, update) {
-			assert.equal(update.current, '0.9.3');
+		updateNotifier(generateSettings()).checkNpm(function(error, update) {
+			assert.equal(update.current, '0.1.0');
 			cb();
 		});
+	});
+
+	it('should check for update with callback', function(cb) {
+		updateNotifier(generateSettings({
+			callback: cb
+		}));
 	});
 });


### PR DESCRIPTION
(https://github.com/yeoman/generator/pull/262)

Added in support a check for an urgent response from the request for update information.

This could use cleaning up to not use config store at all if asking for a response immediately, maybe?

Currently, if a { callback: function {} } is passed in at instantiation, `this.sync` is flipped to true, which later forces an inline call to `this.checkNpm` as opposed to forking.
