### PR TITLE
using spawn() instead of fork()

### DIFF
--- a/lib/update-notifier.js
+++ b/lib/update-notifier.js
@@ -1,7 +1,7 @@
 'use strict';
 var util = require('util');
 var path = require('path');
-var fork = require('child_process').fork;
+var spawn = require('child_process').spawn;
 var Configstore = require('configstore');
 var chalk = require('chalk');
 var semver = require('semver');
@@ -65,10 +65,12 @@ UpdateNotifier.prototype.check = function () {
 	this.options.packageName = this.packageName;
 	this.options.packageVersion = this.packageVersion;
 
-	// Fork, passing the options as an environment property
-	cp = fork(__dirname + '/check.js', [JSON.stringify(this.options)]);
+	// Spawn a detached process, passing the options as an environment property
+	cp = spawn(process.execPath, [path.join(__dirname, 'check.js'), JSON.stringify(this.options)], {
+		detached: true,
+		stdio: 'ignore'
+	});
 	cp.unref();
-	cp.disconnect();
 };
 
 UpdateNotifier.prototype.checkNpm = function (cb) {


### PR DESCRIPTION
By using a detached process a quick parent doesn't prematurely kill the slow child (which would block the update from ever being completed successfully)

From the docs of spawn():

> If the `detached` option is set, the child process will be made the leader of a new process group. This makes it possible for the child to continue running after the parent exits. 

This is not the same as just calling `unref()` and `disconnect()` on a fork()

fixes #21 

I've got this code in the wild for a while (as git-url dependency). 

I re-tested this today: with npm version of `update-notifier` without the callback I never get an update: after resetting the `lastUpdateCheck` to zero and running the app the config the `lastUpdateCheck` gets updated but the `update` never shows up. 

When I swap it for this patched version it works as expected.
