### PR TITLE
fix update command

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ UpdateNotifier.prototype.notify = function (opts) {
 
 	var line1 = ' Update available: ' + chalk.green.bold(this.update.latest) +
 		chalk.dim(' (current: ' + this.update.current + ')') + ' ';
-	var line2 = ' Run ' + chalk.blue('npm update -g ' + this.packageName) +
+	var line2 = ' Run ' + chalk.blue('npm install -g ' + this.packageName) +
 		' to update. ';
 	var contentWidth = Math.max(stringLength(line1), stringLength(line2));
 	var line1rest = contentWidth - stringLength(line1);


### PR DESCRIPTION
According to the [npm documentation](https://docs.npmjs.com/getting-started/updating-global-packages), the command to update a global package is `npm install -g packageName`.

I do not really know what `npm update -g packageName` does but I am sure it will not install the latest versio of the package.
Found when I tried to update bower.