### PR TITLE
Update number of update-notifier dependencies

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ There are a bunch projects using it:
 - [Hoodie CLI](http://hood.ie) - Hoodie command line tool
 - [Roots](http://roots.cx) - A toolkit for advanced front-end development
 
-[And 100+ more...](https://www.npmjs.org/browse/depended/update-notifier)
+[And 600+ more...](https://www.npmjs.org/browse/depended/update-notifier)
 
 
 ## License


### PR DESCRIPTION
The number of modules pulling update-notifier in as a dependency has ballooned from 100+ to [600+](https://www.npmjs.com/browse/depended/update-notifier?offset=606)