### PR TITLE
Change configstore dependency version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Update notifications for your CLI app",
   "license": "BSD-2-Clause",
   "repository": "yeoman/update-notifier",
+  "bugs": "https://github.com/yeoman/update-notifier/issues",
   "author": {
     "name": "Sindre Sorhus",
     "email": "sindresorhus@gmail.com",
@@ -35,7 +36,7 @@
   "dependencies": {
     "boxen": "^0.3.1",
     "chalk": "^1.0.0",
-    "configstore": "^1.0.0",
+    "configstore": "^2.0.0",
     "is-npm": "^1.0.0",
     "latest-version": "^2.0.0",
     "semver-diff": "^2.0.0"


### PR DESCRIPTION
This PR addresses issue #72.
According to the [release notes of configstore](https://github.com/yeoman/configstore/releases/tag/v2.0.0), there has been added support for dot notations. Since update-notifier does not use dots in its config values, this should be fine by just changing the referenced version.