### PR TITLE
Show deferred message on SIGINT as well as exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,10 @@ UpdateNotifier.prototype.notify = function (opts) {
 		process.on('exit', function () {
 			console.error(message);
 		});
+
+		process.on('SIGINT', function () {
+			console.error('\n' + message);
+		});
 	} else {
 		console.error(message);
 	}


### PR DESCRIPTION
Fixes #74.

The extra newline is to leave a space after the `^C` that written into the console buffer when you ctrl+C. (I know there's already a newline at the start of `message`, but it needs two in the case of a sigint otherwise it appears to start on the line immediately following `^C`.)