### PR TITLE
feat: handle configstore error gracefully

### DIFF
--- a/check.js
+++ b/check.js
@@ -1,3 +1,4 @@
+/* eslint xo/no-process-exit: "off" */
 'use strict';
 var updateNotifier = require('./');
 var options = JSON.parse(process.argv[2]);

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var isNpm = require('is-npm');
 var boxen = require('boxen');
 var xdgBasedir = require('xdg-basedir');
 var stringWidth = require('string-width');
+var ansiAlign = require('ansi-align');
 var ONE_DAY = 1000 * 60 * 60 * 24;
 
 function UpdateNotifier(options) {
@@ -48,21 +49,7 @@ function UpdateNotifier(options) {
 				msg.push(format(' Try running with %s or get access ', chalk.cyan('sudo')));
 				msg.push(' to the local update config store via ');
 				msg.push(chalk.cyan(format(' sudo chown -R $USER:$(id -gn $USER) %s ', xdgBasedir.config)));
-
-				var width;
-				var maxWidth = 0;
-				msg = msg.map(function (str) {
-					width = stringWidth(str);
-					maxWidth = Math.max(width, maxWidth);
-					return {
-						str: str,
-						width: width
-					};
-				}).map(function (obj) {
-					return new Array(Math.floor((maxWidth - obj.width) / 2) + 1).join(' ') + obj.str;
-				}).join('\n');
-
-				console.error('\n' + boxen(msg));
+				console.error('\n' + boxen(ansiAlign.center(msg).join('\n')));
 			});
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -60,7 +60,12 @@ UpdateNotifier.prototype.check = function () {
 		return;
 	}
 
-	if (!this.config || this.config.get('optOut') || 'NO_UPDATE_NOTIFIER' in process.env || process.argv.indexOf('--no-update-notifier') !== -1) {
+	if (
+		!this.config ||
+		this.config.get('optOut') ||
+		'NO_UPDATE_NOTIFIER' in process.env ||
+		process.argv.indexOf('--no-update-notifier') !== -1
+	) {
 		return;
 	}
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ var latestVersion = require('latest-version');
 var isNpm = require('is-npm');
 var boxen = require('boxen');
 var xdgBasedir = require('xdg-basedir');
-var stringWidth = require('string-width');
 var ansiAlign = require('ansi-align');
 var ONE_DAY = 1000 * 60 * 60 * 24;
 

--- a/index.js
+++ b/index.js
@@ -59,10 +59,7 @@ function UpdateNotifier(options) {
 						width: width
 					};
 				}).map(function (obj) {
-					for (var i = 0, pre = Math.floor((maxWidth - obj.width) / 2); i < pre; i++) {
-						obj.str = ' ' + obj.str;
-					}
-					return obj.str;
+					return new Array(Math.floor((maxWidth - obj.width) / 2) + 1).join(' ') + obj.str;
 				}).join('\n');
 
 				console.error('\n' + boxen(msg));

--- a/package.json
+++ b/package.json
@@ -38,9 +38,12 @@
     "configstore": "^2.0.0",
     "is-npm": "^1.0.0",
     "latest-version": "^2.0.0",
-    "semver-diff": "^2.0.0"
+    "semver-diff": "^2.0.0",
+    "string-width": "^1.0.1",
+    "xdg-basedir": "^2.0.0"
   },
   "devDependencies": {
+    "clear-require": "^1.0.1",
     "mocha": "*",
     "xo": "*"
   }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "is-npm": "^1.0.0",
     "latest-version": "^2.0.0",
     "semver-diff": "^2.0.0",
-    "string-width": "^1.0.1",
     "xdg-basedir": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "version"
   ],
   "dependencies": {
+    "ansi-align": "^1.0.0",
     "boxen": "^0.5.1",
     "chalk": "^1.0.0",
     "configstore": "^2.0.0",

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@
 'use strict';
 var assert = require('assert');
 var fs = require('fs');
+var clearRequire = require('clear-require');
 var updateNotifier = require('./');
 
 describe('updateNotifier', function () {
@@ -38,5 +39,33 @@ describe('updateNotifier', function () {
 		updateNotifier(generateSettings({
 			callback: cb
 		}));
+	});
+});
+
+describe('updateNotifier with fs error', function () {
+	before(function () {
+		clearRequire('./');
+		clearRequire('configstore');
+		clearRequire('xdg-basedir');
+		// set configstore.config to something
+		// that requires root access
+		process.env.XDG_CONFIG_HOME = '/usr';
+		updateNotifier = require('./');
+	});
+
+	after(function () {
+		clearRequire('./');
+		clearRequire('configstore');
+		clearRequire('xdg-basedir');
+		delete process.env.XDG_CONFIG_HOME;
+		updateNotifier = require('./');
+	});
+
+	it('should fail gracefully', function () {
+		// basically should not blow up, but config should be undefined
+		assert.ifError(updateNotifier({
+			packageName: 'npme',
+			packageVersion: '3.7.0'
+		}).config);
 	});
 });


### PR DESCRIPTION
Fixes #76.

Catches any error thrown from `configstore` synchronous fs access and gracefully handles it by short-circuiting the update check (via undefined `config`) and printing a pretty notification on process exit.

The notification gives the user suggestions to fix the problem and looks something like this (centered horizontally in boxen):

<img width="445" alt="screen shot 2016-04-28 at 6 30 16 pm" src="https://cloud.githubusercontent.com/assets/1929625/14903481/56c8b6f2-0d6f-11e6-86dc-37c490ac6bce.png">

Also added a test, which works based on the assumptions that:

- You're not running as the root user
- Access to `/usr` requires root access

If the assumptions are not met, the test will fail.

A few other things to note:

1. The notification suggestions are static (**not** platform-specific).
2. I'm not sure how safe the `chown` suggestion is.
3. In order to output the correct `configstore` directory, I added `xdg-basedir` as a direct dependency, but my logic doesn't account for a [potential tmp dir like `configstore` does](https://github.com/yeoman/configstore/blob/v2.0.0/index.js#L13-L14).

Also, some of the logic could possibly be better structured - (~~I looked for a package to make the center alignment easier but didn't find one, am now thinking of creating one myself~~ created [ansi-align](https://github.com/nexdrew/ansi-align)) - but other than that, it works and is better than crashing the bin.