### PR TITLE
feat: center-align message via boxen@0.6.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ var latestVersion = require('latest-version');
 var isNpm = require('is-npm');
 var boxen = require('boxen');
 var xdgBasedir = require('xdg-basedir');
-var ansiAlign = require('ansi-align');
 var ONE_DAY = 1000 * 60 * 60 * 24;
 
 function UpdateNotifier(options) {
@@ -43,12 +42,14 @@ function UpdateNotifier(options) {
 			});
 		} catch (_) {
 			// expecting error code EACCES or EPERM
+			var msg =
+				chalk.yellow(format(' %s update check failed ', options.pkg.name)) +
+				format('\n Try running with %s or get access ', chalk.cyan('sudo')) +
+				'\n to the local update config store via \n' +
+				chalk.cyan(format(' sudo chown -R $USER:$(id -gn $USER) %s ', xdgBasedir.config));
+
 			process.on('exit', function () {
-				var msg = [chalk.yellow(format(' %s update check failed ', options.pkg.name))];
-				msg.push(format(' Try running with %s or get access ', chalk.cyan('sudo')));
-				msg.push(' to the local update config store via ');
-				msg.push(chalk.cyan(format(' sudo chown -R $USER:$(id -gn $USER) %s ', xdgBasedir.config)));
-				console.error('\n' + boxen(ansiAlign.center(msg).join('\n')));
+				console.error('\n' + boxen(msg, {align: 'center'}));
 			});
 		}
 	}
@@ -108,6 +109,7 @@ UpdateNotifier.prototype.notify = function (opts) {
 	var message = '\n' + boxen('Update available ' + chalk.dim(this.update.current) + chalk.reset(' → ') + chalk.green(this.update.latest) + ' \nRun ' + chalk.cyan('npm i -g ' + this.packageName) + ' to update', {
 		padding: 1,
 		margin: 1,
+		align: 'center',
 		borderColor: 'yellow',
 		borderStyle: 'round'
 	});

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "version"
   ],
   "dependencies": {
-    "ansi-align": "^1.0.0",
-    "boxen": "^0.5.1",
+    "boxen": "^0.6.0",
     "chalk": "^1.0.0",
     "configstore": "^2.0.0",
     "is-npm": "^1.0.0",
@@ -44,7 +43,9 @@
   },
   "devDependencies": {
     "clear-require": "^1.0.1",
+    "fixture-stdout": "^0.2.1",
     "mocha": "*",
+    "strip-ansi": "^3.0.1",
     "xo": "*"
   }
 }

--- a/test.js
+++ b/test.js
@@ -8,11 +8,6 @@ var FixtureStdout = require('fixture-stdout');
 var stripAnsi = require('strip-ansi');
 var updateNotifier = require('./');
 
-function clearRequireAnd(modules, fn) {
-	modules.forEach(clearRequire);
-	fn();
-}
-
 describe('updateNotifier', function () {
 	var generateSettings = function (options) {
 		options = options || {};
@@ -52,19 +47,17 @@ describe('updateNotifier', function () {
 
 describe('updateNotifier with fs error', function () {
 	before(function () {
-		clearRequireAnd(['./', 'configstore', 'xdg-basedir'], function () {
-			// set configstore.config to something
-			// that requires root access
-			process.env.XDG_CONFIG_HOME = '/usr';
-			updateNotifier = require('./');
-		});
+		['./', 'configstore', 'xdg-basedir'].forEach(clearRequire);
+		// set configstore.config to something
+		// that requires root access
+		process.env.XDG_CONFIG_HOME = '/usr';
+		updateNotifier = require('./');
 	});
 
 	after(function () {
-		clearRequireAnd(['./', 'configstore', 'xdg-basedir'], function () {
-			delete process.env.XDG_CONFIG_HOME;
-			updateNotifier = require('./');
-		});
+		['./', 'configstore', 'xdg-basedir'].forEach(clearRequire);
+		delete process.env.XDG_CONFIG_HOME;
+		updateNotifier = require('./');
 	});
 
 	it('should fail gracefully', function () {
@@ -84,25 +77,23 @@ describe('notify(opts)', function () {
 	var isTTYBefore;
 
 	before(function () {
-		clearRequireAnd(['./', 'is-npm'], function () {
-			processEnvBefore = JSON.stringify(process.env);
-			isTTYBefore = process.stdout.isTTY;
-			['npm_config_username', 'npm_package_name', 'npm_config_heading'].forEach(function (name) {
-				delete process.env[name];
-			});
-			process.stdout.isTTY = true;
-			updateNotifier = require('./');
+		['./', 'is-npm'].forEach(clearRequire);
+		processEnvBefore = JSON.stringify(process.env);
+		isTTYBefore = process.stdout.isTTY;
+		['npm_config_username', 'npm_package_name', 'npm_config_heading'].forEach(function (name) {
+			delete process.env[name];
 		});
+		process.stdout.isTTY = true;
+		updateNotifier = require('./');
 	});
 
 	after(function () {
-		clearRequireAnd(['./', 'is-npm'], function () {
-			process.env = JSON.parse(processEnvBefore);
-			process.stdout.isTTY = isTTYBefore;
-			processEnvBefore = undefined;
-			isTTYBefore = undefined;
-			updateNotifier = require('./');
-		});
+		['./', 'is-npm'].forEach(clearRequire);
+		process.env = JSON.parse(processEnvBefore);
+		process.stdout.isTTY = isTTYBefore;
+		processEnvBefore = undefined;
+		isTTYBefore = undefined;
+		updateNotifier = require('./');
 	});
 
 	var errorLogs = '';


### PR DESCRIPTION
Replace the explicit use of `ansi-align` with the new `align: 'center'` option [available in `boxen@0.6.0`](https://github.com/sindresorhus/boxen/tree/v0.6.0#align).

Add center-alignment for the default `.notify()` message, with test to verify output.

The "update check failed" message used when `configstore` throws was already center-aligned, but this PR will defer alignment to `boxen`.