### PR TITLE
docs: add align: 'center' to default boxenOpts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ The message that will be shown when an update is available.
 ### options.boxenOpts
 
 Type: `object`<br>
-Default: `{ padding: 1, margin: 1, borderColor: 'yellow', borderStyle: 'round' }` ([See the screen shot above](https://github.com/yeoman/update-notifier#update-notifier-))
+Default: `{ padding: 1, margin: 1, align: 'center', borderColor: 'yellow', borderStyle: 'round' }` ([See the screen shot above](https://github.com/yeoman/update-notifier#update-notifier-))
 
 The object that will be passed to [boxen](https://github.com/sindresorhus/boxen).
 


### PR DESCRIPTION
Just a minor tweak to "correct" the default `options.boxenOpts` listed in the readme. This only came about because #83 and #84 were developed separately in parallel.

Note that we _may_ want to update the screenshot to show center alignment (first line would move to the right by one space). If I could produce terminal output that looked that good, I would do this myself, but I can't get the box to look quite right.