### PR TITLE
docs: h3 -> h4 for options.boxenOpts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,7 +125,7 @@ Default: [See the screen shot above](https://github.com/yeoman/update-notifier#u
 
 The message that will be shown when an update is available.
 
-### options.boxenOpts
+#### options.boxenOpts
 
 Type: `object`<br>
 Default: `{ padding: 1, margin: 1, align: 'center', borderColor: 'yellow', borderStyle: 'round' }` ([See the screen shot above](https://github.com/yeoman/update-notifier#update-notifier-))


### PR DESCRIPTION
Sorry, just noticed the header level for `options.boxenOpts` was inconsistent in the readme. Silly, I know, but I couldn't let it go.