### PR TITLE
WIP: extract UpdateChecker and Notifier for general use

### DIFF
--- a/check.js
+++ b/check.js
@@ -1,17 +1,17 @@
-/* eslint-disable xo/no-process-exit */
+/* eslint-disable unicorn/no-process-exit */
 'use strict';
-var updateNotifier = require('./');
+var updateChecker = require('./');
 
 var options = JSON.parse(process.argv[2]);
 
-updateNotifier = new updateNotifier.UpdateNotifier(options);
+updateChecker = new updateChecker.UpdateChecker(options);
 
-updateNotifier.checkNpm().then(function (update) {
+updateChecker.checkLatest().then(function (update) {
 	// only update the last update check time on success
-	updateNotifier.config.set('lastUpdateCheck', Date.now());
+	updateChecker.config.set('lastUpdateCheck', Date.now());
 
 	if (update.type && update.type !== 'latest') {
-		updateNotifier.config.set('update', update);
+		updateChecker.config.set('update', update);
 	}
 
 	// Call process exit explicitly to terminate the child process

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,5 +1,5 @@
 'use strict';
-var updateNotifier = require('./');
+var updateNotifier = require('../');
 
 // you have to run this file two times the first time
 

--- a/examples/custom-notifier.js
+++ b/examples/custom-notifier.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var lazyRequire = require('lazy-req')(require);
+
+var chalk = lazyRequire('chalk');
+
+var Notifier = require('../index.js').Notifier;
+var UpdateChecker = require('../index.js').UpdateChecker;
+
+function CustomNotifier(options) {
+	this.options = options = options || {};
+
+	this.updateChecker = new UpdateChecker({
+		currentVersion: '1.0.0',
+		getLatest: function () {
+			// asynchronously retrieve latest version from remote
+			// does not have to be an NPM look-up, could be anything
+			return Promise.resolve('1.2.3');
+		},
+		updaterName: 'custom'
+	});
+}
+
+CustomNotifier.prototype.check = function () {
+	return this.updateChecker.check();
+};
+
+CustomNotifier.prototype.notify = function (opts) {
+	var notifier = new Notifier();
+
+	opts = opts || {};
+
+	opts.update = (this.updateChecker && this.updateChecker.update) || {};
+
+	opts.message = opts.message || 'Update available ' + chalk().dim(opts.update.current) + chalk().reset(' → ') +
+		chalk().green(opts.update.latest) + ' \nRun ' + chalk().cyan('custom update command') + ' to update';
+
+	return notifier.notify(opts);
+};
+
+module.exports = function (options) {
+	var updateNotifier = new CustomNotifier(options);
+	updateNotifier.check();
+	return updateNotifier;
+};
+
+module.exports.CustomNotifier = CustomNotifier;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && mocha --timeout 20000"
+    "test": "if-node-version \">=4\" xo && mocha --timeout 20000"
   },
   "files": [
     "index.js",
@@ -45,6 +45,7 @@
   "devDependencies": {
     "clear-require": "^1.0.1",
     "fixture-stdout": "^0.2.1",
+    "if-node-version": "^1.1.0",
     "mocha": "*",
     "strip-ansi": "^3.0.1",
     "xo": "*"

--- a/test.js
+++ b/test.js
@@ -8,6 +8,20 @@ var FixtureStdout = require('fixture-stdout');
 var stripAnsi = require('strip-ansi');
 var updateNotifier = require('./');
 
+describe('module', function () {
+	it('should export a function', function () {
+		assert.equal(typeof updateNotifier, 'function');
+	});
+
+	it('should export a Notifier constructor', function () {
+		assert.equal(typeof updateNotifier.Notifier, 'function');
+	});
+
+	it('should export a UpdateChecker constructor', function () {
+		assert.equal(typeof updateNotifier.UpdateChecker, 'function');
+	});
+});
+
 describe('updateNotifier', function () {
 	var generateSettings = function (options) {
 		options = options || {};
@@ -113,9 +127,11 @@ describe('notify(opts)', function () {
 	it('should use pretty boxen message by default', function () {
 		function Control() {
 			this.packageName = 'update-notifier-tester';
-			this.update = {
-				current: '0.0.2',
-				latest: '1.0.0'
+			this.updateChecker = {
+				update: {
+					current: '0.0.2',
+					latest: '1.0.0'
+				}
 			};
 		}
 		util.inherits(Control, updateNotifier.UpdateNotifier);


### PR DESCRIPTION
I have a use case that involves checking for updates to things that are not in the NPM registry. I considered copying this project and modifying it for my other use cases, but I thought I'd try this refactoring PR first just to see if it flies. :)

- theoretically a pure "extract" refactoring, no real compatibility breakage or changes in behaviour

- noticed that `update.name` is not used, so I removed it: https://github.com/yeoman/update-notifier/blob/v1.0.2/index.js#L99

- extracted UpdateChecker constructor, responsible for executing check in child process and saving results to the config file

- extracted Notifier constructor, responsible for displaying messages to the user

- still export prior UpdateNotifier constructor, but internally rename it to PackageUpdateNotifier

- rework PackageUpdateNotifier to use UpdateChecker and Notifier, deduplicating code

- added an example of a CustomNotifier that implements a non-NPM check: https://github.com/jokeyrhyme/update-notifier/blob/extract-update-checker/examples/custom-notifier.js

I completely understand if you feel this is beyond the scope of this project. Let me know what you think. :)