### PR TITLE
get tests passing on Travis CI with latest xo, etc

### DIFF
--- a/check.js
+++ b/check.js
@@ -1,4 +1,4 @@
-/* eslint-disable xo/no-process-exit */
+/* eslint-disable unicorn/no-process-exit */
 'use strict';
 var updateNotifier = require('./');
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "xo && mocha --timeout 20000"
+    "test": "if-node-version \">=4\" xo && mocha --timeout 20000"
   },
   "files": [
     "index.js",
@@ -45,6 +45,7 @@
   "devDependencies": {
     "clear-require": "^1.0.1",
     "fixture-stdout": "^0.2.1",
+    "if-node-version": "^1.1.0",
     "mocha": "*",
     "strip-ansi": "^3.0.1",
     "xo": "*"


### PR DESCRIPTION
- the "xo/no-process-exit" rule is now "unicorn/no-process-exit", so fix an "eslint-disable" line to prevent lint errors

- xo itself requires Node 4.x or newer now (at least according to the thrown errors), so change `npm test` so that it only executes `xo` for compatible Node versions