### PR TITLE
Exit process on SIGINT

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,8 @@ UpdateNotifier.prototype.notify = function (opts) {
 		});
 
 		process.on('SIGINT', function () {
-			console.error('\n' + message);
+			console.error('');
+			process.exit();
 		});
 	}
 


### PR DESCRIPTION
Fix for typicode/json-server#425

#75 Adds a handler for SIGINT that prints out the update message, but forgets to exit the process. That means that whenever you press control-c to stop your program from running, it prints out a nice update message and continues to run.

This PR fixes the problem by calling `process.exit()` in the SIGINT handler. Since the process' `'exit'` handler already prints out the update message, the SIGINT handler doesn't need to. The SIGINT handler still prints out a newline character as in #75.