### PR TITLE
Bump minimum supported `node` version to `node@4`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,3 @@ language: node_js
 node_js:
   - '5'
   - '4'
-  - '0.12'
-  - '0.10'

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "scripts": {
-    "test": "if-node-version \">=4\" xo && mocha --timeout 20000"
+    "test": "xo && mocha --timeout 20000"
   },
   "files": [
     "index.js",
@@ -33,19 +33,18 @@
     "version"
   ],
   "dependencies": {
-    "boxen": "^0.6.0",
+    "boxen": "^1.0.0",
     "chalk": "^1.0.0",
     "configstore": "^2.0.0",
     "is-npm": "^1.0.0",
     "latest-version": "^2.0.0",
-    "lazy-req": "^1.1.0",
+    "lazy-req": "^2.0.0",
     "semver-diff": "^2.0.0",
     "xdg-basedir": "^2.0.0"
   },
   "devDependencies": {
-    "clear-require": "^1.0.1",
+    "clear-require": "^2.0.0",
     "fixture-stdout": "^0.2.1",
-    "if-node-version": "^1.1.0",
     "mocha": "*",
     "strip-ansi": "^3.0.1",
     "xo": "*"


### PR DESCRIPTION
Also update dependencies.
Would you like to postpone this until a version of `configstore` with https://github.com/yeoman/configstore/pull/49 merged is published?