### PR TITLE
Add option to exclude `-g` argument from default update message

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,9 +107,7 @@ class UpdateNotifier {
 			return this;
 		}
 
-		opts = opts || {};
-
-		opts.isGlobal = typeof opts.isGlobal === 'boolean' ? opts.global : true;
+		opts = Object.assign({isGlobal: true}, opts);
 
 		opts.message = opts.message || 'Update available ' + chalk().dim(this.update.current) + chalk().reset(' → ') +
 			chalk().green(this.update.latest) + ' \nRun ' + chalk().cyan('npm i ' + (opts.isGlobal ? '-g ' : '') + this.packageName) + ' to update';

--- a/index.js
+++ b/index.js
@@ -109,8 +109,10 @@ class UpdateNotifier {
 
 		opts = opts || {};
 
+		opts.isGlobal = typeof opts.isGlobal === 'boolean' ? opts.global : true;
+
 		opts.message = opts.message || 'Update available ' + chalk().dim(this.update.current) + chalk().reset(' → ') +
-			chalk().green(this.update.latest) + ' \nRun ' + chalk().cyan('npm i -g ' + this.packageName) + ' to update';
+			chalk().green(this.update.latest) + ' \nRun ' + chalk().cyan('npm i ' + (opts.isGlobal ? '-g ' : '') + this.packageName) + ' to update';
 
 		opts.boxenOpts = opts.boxenOpts || {
 			padding: 1,

--- a/readme.md
+++ b/readme.md
@@ -136,7 +136,7 @@ Message that will be shown when an update is available.
 Type: `boolean`<br>
 Default: `true`
 
-Include the `-g` argument in the default message's `npm i` recommendation. This is ignored if you supply your own `message`.
+Include the `-g` argument in the default message's `npm i` recommendation. You may want to change this if your CLI package can be installed as a dependency of another project, and don't want to recommend a global installation. This option is ignored if you supply your own `message` (see above).
 
 ##### boxenOpts
 

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,13 @@ Default: [See above screenshot](https://github.com/yeoman/update-notifier#update
 
 Message that will be shown when an update is available.
 
+##### isGlobal
+
+Type: `boolean`<br>
+Default: `true`
+
+Include the `-g` argument in the default message's `npm i` recommendation. This is ignored if you supply your own `message`.
+
 ##### boxenOpts
 
 Type: `Object`<br>

--- a/test.js
+++ b/test.js
@@ -97,6 +97,15 @@ describe('notify(opts)', () => {
 		updateNotifier = require('./');
 	});
 
+	function Control() {
+		this.packageName = 'update-notifier-tester';
+		this.update = {
+			current: '0.0.2',
+			latest: '1.0.0'
+		};
+	}
+	util.inherits(Control, updateNotifier.UpdateNotifier);
+
 	let errorLogs = '';
 
 	beforeEach(() => {
@@ -112,14 +121,6 @@ describe('notify(opts)', () => {
 	});
 
 	it('should use pretty boxen message by default', () => {
-		function Control() {
-			this.packageName = 'update-notifier-tester';
-			this.update = {
-				current: '0.0.2',
-				latest: '1.0.0'
-			};
-		}
-		util.inherits(Control, updateNotifier.UpdateNotifier);
 		const notifier = new Control();
 		notifier.notify({defer: false});
 		assert.equal(stripAnsi(errorLogs), [
@@ -137,27 +138,9 @@ describe('notify(opts)', () => {
 	});
 
 	it('should exclude -g argument when `isGlobal` option is `false`', () => {
-		function Control() {
-			this.packageName = 'update-notifier-tester';
-			this.update = {
-				current: '0.0.2',
-				latest: '1.0.0'
-			};
-		}
-		util.inherits(Control, updateNotifier.UpdateNotifier);
 		const notifier = new Control();
 		notifier.notify({defer: false, isGlobal: false});
-		assert.equal(stripAnsi(errorLogs), [
-			'',
-			'',
-			'   ╭────────────────────────────────────────────────╮',
-			'   │                                                │',
-			'   │        Update available 0.0.2 → 1.0.0          │',
-			'   │   Run npm i update-notifier-tester to update   │',
-			'   │                                                │',
-			'   ╰────────────────────────────────────────────────╯',
-			'',
-			''
-		].join('\n'));
+		assert.notEqual(-1, stripAnsi(errorLogs)
+			.indexOf('Run npm i update-notifier-tester to update'));
 	});
 });

--- a/test.js
+++ b/test.js
@@ -135,4 +135,29 @@ describe('notify(opts)', () => {
 			''
 		].join('\n'));
 	});
+
+	it('should exclude -g argument when `isGlobal` option is `false`', () => {
+		function Control() {
+			this.packageName = 'update-notifier-tester';
+			this.update = {
+				current: '0.0.2',
+				latest: '1.0.0'
+			};
+		}
+		util.inherits(Control, updateNotifier.UpdateNotifier);
+		const notifier = new Control();
+		notifier.notify({defer: false, isGlobal: false});
+		assert.equal(stripAnsi(errorLogs), [
+			'',
+			'',
+			'   ╭────────────────────────────────────────────────╮',
+			'   │                                                │',
+			'   │        Update available 0.0.2 → 1.0.0          │',
+			'   │   Run npm i update-notifier-tester to update   │',
+			'   │                                                │',
+			'   ╰────────────────────────────────────────────────╯',
+			'',
+			''
+		].join('\n'));
+	});
 });


### PR DESCRIPTION
In cases where your CLI package also serves a secondary purpose as a dependency of a project (e.g. the new crop of single-dependency toolkits such as [nwb](https://github.com/insin/nwb)), the default update message shouldn't be recommending a global npm install.

With this new option (`isGlobal`), the default behaviour stays the same, but it is now configurable. Of course, this has always been possible when using the `message` argument, but it's a shame for authors to lose out on the pretty boxen output when they just want to change a flag.

I've updated the tests to ensure this output is correct, but they could use a little refactoring now that more than one test uses a similar `UpdateNotifier` sub-class.