### PR TITLE
Bail if notify is disabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,10 @@ class UpdateNotifier {
 		this.updateCheckInterval = typeof options.updateCheckInterval === 'number' ? options.updateCheckInterval : ONE_DAY;
 		this.hasCallback = typeof options.callback === 'function';
 		this.callback = options.callback || (() => {});
+		this.disabled = 'NO_UPDATE_NOTIFIER' in process.env ||
+			process.argv.indexOf('--no-update-notifier') !== -1;
 
-		if (!this.hasCallback) {
+		if (!this.disabled && !this.hasCallback) {
 			try {
 				const ConfigStore = configstore();
 				this.config = new ConfigStore(`update-notifier-${this.packageName}`, {
@@ -70,8 +72,7 @@ class UpdateNotifier {
 		if (
 			!this.config ||
 			this.config.get('optOut') ||
-			'NO_UPDATE_NOTIFIER' in process.env ||
-			process.argv.indexOf('--no-update-notifier') !== -1
+			this.disabled
 		) {
 			return;
 		}

--- a/test.js
+++ b/test.js
@@ -19,6 +19,7 @@ describe('updateNotifier', () => {
 			callback: options.callback || null
 		};
 	};
+	const argv = process.argv.slice(0);
 
 	let configstorePath;
 
@@ -27,6 +28,8 @@ describe('updateNotifier', () => {
 	});
 
 	afterEach(() => {
+		delete process.env.NO_UPDATE_NOTIFIER;
+		process.argv = argv;
 		setTimeout(() => {
 			fs.unlinkSync(configstorePath);
 		}, 10000);
@@ -42,6 +45,18 @@ describe('updateNotifier', () => {
 		updateNotifier(generateSettings({
 			callback: cb
 		}));
+	});
+
+	it('should not initialize configStore when NO_UPDATE_NOTIFIER is set', () => {
+		process.env.NO_UPDATE_NOTIFIER = '1';
+		const notifier = updateNotifier(generateSettings());
+		assert.equal(notifier.config, undefined);
+	});
+
+	it('should not initialize configStore when --no-update-notifier is set', () => {
+		process.argv.push('--no-update-notifier');
+		const notifier = updateNotifier(generateSettings());
+		assert.equal(notifier.config, undefined);
 	});
 });
 

--- a/test.js
+++ b/test.js
@@ -19,11 +19,12 @@ describe('updateNotifier', () => {
 			callback: options.callback || null
 		};
 	};
-	const argv = process.argv.slice(0);
 
+	let argv;
 	let configstorePath;
 
 	beforeEach(() => {
+		argv = process.argv.slice();
 		configstorePath = updateNotifier(generateSettings()).config.path;
 	});
 


### PR DESCRIPTION
Avoids initializing configStore and showing related errors if environment variable or argv disables notifier.

Rel #107