### PR TITLE
Add ability to bypass isNpm check with `shouldNotifyInNpmScript` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ class UpdateNotifier {
 		this.callback = options.callback || (() => {});
 		this.disabled = 'NO_UPDATE_NOTIFIER' in process.env ||
 			process.argv.indexOf('--no-update-notifier') !== -1;
+		this.skipIsNpmCheck = options.shouldNotifyInNpmScript;
 
 		if (!this.disabled && !this.hasCallback) {
 			try {
@@ -106,7 +107,8 @@ class UpdateNotifier {
 		});
 	}
 	notify(opts) {
-		if (!process.stdout.isTTY || isNpm() || !this.update) {
+		const suppressForNpm = !this.skipIsNpmCheck && isNpm();
+		if (!process.stdout.isTTY || suppressForNpm || !this.update) {
 			return this;
 		}
 

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ class UpdateNotifier {
 		this.disabled = 'NO_UPDATE_NOTIFIER' in process.env ||
 			process.argv.indexOf('--no-update-notifier') !== -1 ||
 			isCi();
-		this.skipIsNpmCheck = options.shouldNotifyInNpmScript;
+		this.shouldNotifyInNpmScript = options.shouldNotifyInNpmScript;
 
 		if (!this.disabled && !this.hasCallback) {
 			try {
@@ -109,7 +109,7 @@ class UpdateNotifier {
 		});
 	}
 	notify(opts) {
-		const suppressForNpm = !this.skipIsNpmCheck && isNpm();
+		const suppressForNpm = !this.shouldNotifyInNpmScript && isNpm();
 		if (!process.stdout.isTTY || suppressForNpm || !this.update) {
 			return this;
 		}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "ava": "*",
     "clear-module": "^2.1.0",
     "fixture-stdout": "^0.2.1",
+    "mock-require": "^2.0.2",
     "strip-ansi": "^4.0.0",
     "xo": "^0.18.2"
   }

--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,13 @@ Default: `{padding: 1, margin: 1, align: 'center', borderColor: 'yellow', border
 
 Options object that will be passed to [`boxen`](https://github.com/sindresorhus/boxen).
 
+##### shouldNotifyInNpmScript
+
+Type: `boolean`<br>
+Default: `false`
+
+Allows notification to be shown when running as an npm script
+
 ### User settings
 
 Users of your module have the ability to opt-out of the update notifier by changing the `optOut` property to `true` in `~/.config/configstore/update-notifier-[your-module-name].json`. The path is available in `notifier.config.path`.

--- a/readme.md
+++ b/readme.md
@@ -158,7 +158,7 @@ Options object that will be passed to [`boxen`](https://github.com/sindresorhus/
 Type: `boolean`<br>
 Default: `false`
 
-Allows notification to be shown when running as an npm script
+Allows notification to be shown when running as an npm script.
 
 ### User settings
 

--- a/test/notify.js
+++ b/test/notify.js
@@ -9,13 +9,13 @@ const stderr = new FixtureStdout({
 	stream: process.stderr
 });
 
-function Control(skipIsNpmCheck) {
+function Control(shouldNotifyInNpmScript) {
 	this.packageName = 'update-notifier-tester';
 	this.update = {
 		current: '0.0.2',
 		latest: '1.0.0'
 	};
-	this.skipIsNpmCheck = skipIsNpmCheck;
+	this.shouldNotifyInNpmScript = shouldNotifyInNpmScript;
 }
 
 const setupTest = isNpmReturnValue => {
@@ -64,7 +64,7 @@ test('exclude -g argument when `isGlobal` option is `false`', t => {
 	t.not(stripAnsi(errorLogs).indexOf('Run npm i update-notifier-tester to update'), -1);
 });
 
-test('skipIsNpmCheck should default to false', t => {
+test('shouldNotifyInNpmScript should default to false', t => {
 	const notifier = new Control();
 	notifier.notify({defer: false});
 	t.not(stripAnsi(errorLogs).indexOf('Update available'), -1);
@@ -77,7 +77,7 @@ test('suppress output when running as npm script', t => {
 	t.is(stripAnsi(errorLogs).indexOf('Update available'), -1);
 });
 
-test('should ouput if running as npm script and skipIsNpmCheck option set', t => {
+test('should ouput if running as npm script and shouldNotifyInNpmScript option set', t => {
 	setupTest(true);
 	const notifier = new Control(true);
 	notifier.notify({defer: false});

--- a/test/notify.js
+++ b/test/notify.js
@@ -3,33 +3,33 @@ import clearModule from 'clear-module';
 import FixtureStdout from 'fixture-stdout';
 import stripAnsi from 'strip-ansi';
 import test from 'ava';
+import mock from 'mock-require';
 
 const stderr = new FixtureStdout({
 	stream: process.stderr
 });
-let updateNotifier = require('..');
 
-test.before(() => {
-	['.', 'is-npm'].forEach(clearModule);
-	['npm_config_username', 'npm_package_name', 'npm_config_heading'].forEach(name => {
-		delete process.env[name];
-	});
-	process.stdout.isTTY = true;
-	updateNotifier = require('..');
-});
-
-function Control() {
+function Control(skipIsNpmCheck) {
 	this.packageName = 'update-notifier-tester';
 	this.update = {
 		current: '0.0.2',
 		latest: '1.0.0'
 	};
+	this.skipIsNpmCheck = skipIsNpmCheck;
 }
-util.inherits(Control, updateNotifier.UpdateNotifier);
+
+const setupTest = isNpmReturnValue => {
+	['.', 'is-npm'].forEach(clearModule);
+	process.stdout.isTTY = true;
+	mock('is-npm', isNpmReturnValue || false);
+	const updateNotifier = require('..');
+	util.inherits(Control, updateNotifier.UpdateNotifier);
+};
 
 let errorLogs = '';
 
 test.beforeEach(() => {
+	setupTest();
 	stderr.capture(s => {
 		errorLogs += s;
 		return false;
@@ -37,6 +37,7 @@ test.beforeEach(() => {
 });
 
 test.afterEach(() => {
+	mock.stopAll();
 	stderr.release();
 	errorLogs = '';
 });
@@ -61,4 +62,24 @@ test('exclude -g argument when `isGlobal` option is `false`', t => {
 	const notifier = new Control();
 	notifier.notify({defer: false, isGlobal: false});
 	t.not(stripAnsi(errorLogs).indexOf('Run npm i update-notifier-tester to update'), -1);
+});
+
+test('skipIsNpmCheck should default to false', t => {
+	const notifier = new Control();
+	notifier.notify({defer: false});
+	t.not(stripAnsi(errorLogs).indexOf('Update available'), -1);
+});
+
+test('suppress output when running as npm script', t => {
+	setupTest(true);
+	const notifier = new Control();
+	notifier.notify({defer: false});
+	t.is(stripAnsi(errorLogs).indexOf('Update available'), -1);
+});
+
+test('should ouput if running as npm script and skipIsNpmCheck option set', t => {
+	setupTest(true);
+	const notifier = new Control(true);
+	notifier.notify({defer: false});
+	t.not(stripAnsi(errorLogs).indexOf('Update available'), -1);
 });


### PR DESCRIPTION
My team and I have run into multiple scenarios where we've wanted to output the update message when running as an npm script.  To do this, we've had to dig through the source code, hack environment variables, run this package, and reset environment variables.

This PR include functionality to bypass the isNpm() check.  This will not break any existing functionality.

---

Fixes #122 