### PR TITLE
Recheck version before notifying

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,8 +111,8 @@ class UpdateNotifier {
 		if (!process.stdout.isTTY || isNpm() || !this.update) {
 			return this;
 		}
-		
-		if(this.options.pkg.version === this.update.latest) {
+
+		if (this.options.pkg.version === this.update.latest) {
 			return this;
 		}
 

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ class UpdateNotifier {
 			return this;
 		}
 		
-		if(this.options.pkg.version == this.update.latest) {
+		if(this.options.pkg.version === this.update.latest) {
 			return this;
 		}
 

--- a/index.js
+++ b/index.js
@@ -111,6 +111,10 @@ class UpdateNotifier {
 		if (!process.stdout.isTTY || isNpm() || !this.update) {
 			return this;
 		}
+		
+		if(this.options.pkg.version == this.update.latest) {
+			return this;
+		}
 
 		opts = Object.assign({isGlobal: isInstalledGlobally()}, opts);
 


### PR DESCRIPTION
This fixes #67
When the previous run resulted in a cached version update, even if the update has already happened, notify was displaying a message to update.