### PR TITLE
Fix URI Scheme in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": {
     "name": "Sindre Sorhus",
     "email": "sindresorhus@gmail.com",
-    "url": "sindresorhus.com"
+    "url": "https://sindresorhus.com"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
Just surfing across my node_modules and found this:

![screenshot 188](https://user-images.githubusercontent.com/20214420/37329249-97782cc0-26cf-11e8-9345-02c890b62040.png)

I add `https://` and VSCode no longer complaining about it.