### PR TITLE
Fix path for clearing UpdateNotifier module

### DIFF
--- a/test/fs-error.js
+++ b/test/fs-error.js
@@ -4,7 +4,7 @@ import test from 'ava';
 let updateNotifier;
 
 test.before(() => {
-	['.', 'configstore', 'xdg-basedir'].forEach(clearModule);
+	['..', 'configstore', 'xdg-basedir'].forEach(clearModule);
 	// Set configstore.config to something
 	// that requires root access
 	process.env.XDG_CONFIG_HOME = '/usr';

--- a/test/notify.js
+++ b/test/notify.js
@@ -19,7 +19,7 @@ function Control(shouldNotifyInNpmScript) {
 }
 
 const setupTest = isNpmReturnValue => {
-	['.', 'is-npm'].forEach(clearModule);
+	['..', 'is-npm'].forEach(clearModule);
 	process.stdout.isTTY = true;
 	mock('is-npm', isNpmReturnValue || false);
 	const updateNotifier = require('..');


### PR DESCRIPTION
Given that the patch from https://github.com/sindresorhus/caller-callsite/pull/4 is applied, the tests would throw because they could not find the index module in the test directory. (When the caller-callsite patch is not applied, the tests throw an error as shown in #126 on node >= 8).

```
  Error {
    code: 'MODULE_NOT_FOUND',
    message: 'Cannot find module \'.\'',
  }

  resolveFileName (node_modules/resolve-from/index.js:17:39)
  resolveFrom (node_modules/resolve-from/index.js:31:9)
  module.exports (node_modules/resolve-from/index.js:34:41)
  clear (node_modules/clear-module/index.js:11:23)
  setupTest (test/notify.js:22:18)
  Test._ava2.default.beforeEach [as fn] (test/notify.js:32:2)
```