### PR TITLE
Update `latest-version` package, removing vulnerability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "is-ci": "^1.0.10",
     "is-installed-globally": "^0.1.0",
     "is-npm": "^1.0.0",
-    "latest-version": "^3.0.0",
+    "latest-version": "^3.1.0",
     "semver-diff": "^2.0.0",
     "xdg-basedir": "^3.0.0"
   },


### PR DESCRIPTION
There's a vulnerability with the package `deep-extend`, which is a sub-child of the `latest-version` package. The vulnerability exists on v3.0.0 (what `update-master` is currently using) but is fixed in v3.1.0 (this PR.)

Upgrading it by a minor version fixes the issue.

![screen shot 2019-03-07 at 11 51 29 am](https://user-images.githubusercontent.com/304269/53973800-6a757000-40cf-11e9-88bc-50e469e1ce68.png)
