### PR TITLE
Remove the `callback` option

### DIFF
--- a/check.js
+++ b/check.js
@@ -10,13 +10,13 @@ updateNotifier = new updateNotifier.UpdateNotifier(options);
 	// Exit process when offline
 	setTimeout(process.exit, 1000 * 30);
 
-	const update = await updateNotifier.checkNpm();
+	const diff = await updateNotifier.getSemverDiff();
 
 	// Only update the last update check time on success
 	updateNotifier.config.set('lastUpdateCheck', Date.now());
 
-	if (update.type && update.type !== 'latest') {
-		updateNotifier.config.set('update', update);
+	if (diff.type && diff.type !== 'latest') {
+		updateNotifier.config.set('update', diff);
 	}
 
 	// Call process exit explicitly to terminate the child process,

--- a/check.js
+++ b/check.js
@@ -10,7 +10,7 @@ updateNotifier = new updateNotifier.UpdateNotifier(options);
 	// Exit process when offline
 	setTimeout(process.exit, 1000 * 30);
 
-	const update = await updateNotifier.checkImmediately();
+	const update = await updateNotifier.fetchInfo();
 
 	// Only update the last update check time on success
 	updateNotifier.config.set('lastUpdateCheck', Date.now());

--- a/check.js
+++ b/check.js
@@ -10,13 +10,13 @@ updateNotifier = new updateNotifier.UpdateNotifier(options);
 	// Exit process when offline
 	setTimeout(process.exit, 1000 * 30);
 
-	const diff = await updateNotifier.getSemverDiff();
+	const update = await updateNotifier.checkImmediately();
 
 	// Only update the last update check time on success
 	updateNotifier.config.set('lastUpdateCheck', Date.now());
 
-	if (diff.type && diff.type !== 'latest') {
-		updateNotifier.config.set('update', diff);
+	if (update.type && update.type !== 'latest') {
+		updateNotifier.config.set('update', update);
 	}
 
 	// Call process exit explicitly to terminate the child process,

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ class UpdateNotifier {
 		}).unref();
 	}
 
-	async checkImmediately() {
+	async fetchInfo() {
 		const {distTag} = this.options;
 		const latest = await latestVersion()(this.packageName, {version: distTag});
 

--- a/index.js
+++ b/index.js
@@ -38,14 +38,12 @@ class UpdateNotifier {
 		this.packageName = options.pkg.name;
 		this.packageVersion = options.pkg.version;
 		this.updateCheckInterval = typeof options.updateCheckInterval === 'number' ? options.updateCheckInterval : ONE_DAY;
-		this.hasCallback = typeof options.callback === 'function';
-		this.callback = options.callback || (() => {});
 		this.disabled = 'NO_UPDATE_NOTIFIER' in process.env ||
 			process.argv.includes('--no-update-notifier') ||
 			isCi();
 		this.shouldNotifyInNpmScript = options.shouldNotifyInNpmScript;
 
-		if (!this.disabled && !this.hasCallback) {
+		if (!this.disabled) {
 			try {
 				const ConfigStore = configstore();
 				this.config = new ConfigStore(`update-notifier-${this.packageName}`, {
@@ -70,18 +68,6 @@ class UpdateNotifier {
 	}
 
 	check() {
-		if (this.hasCallback) {
-			(async () => {
-				try {
-					this.callback(null, await this.checkNpm());
-				} catch (error) {
-					this.callback(error);
-				}
-			})();
-
-			return;
-		}
-
 		if (
 			!this.config ||
 			this.config.get('optOut') ||

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ class UpdateNotifier {
 		}).unref();
 	}
 
-	async checkNpm() {
+	async getSemverDiff() {
 		const {distTag} = this.options;
 		const latest = await latestVersion()(this.packageName, {version: distTag});
 

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ class UpdateNotifier {
 		}).unref();
 	}
 
-	async getSemverDiff() {
+	async checkImmediately() {
 		const {distTag} = this.options;
 		const latest = await latestVersion()(this.packageName, {version: distTag});
 

--- a/readme.md
+++ b/readme.md
@@ -138,9 +138,16 @@ Default: `latest`
 
 Which [dist-tag](https://docs.npmjs.com/adding-dist-tags-to-packages) to use to find the latest version.
 
-### notifier.getSemverDiff()
+### notifier.checkImmediately()
 
-Get semver difference directly. This method will not trigger the checking process.
+Check update immediately. This method will not trigger the checking process.
+
+Returns an `object` with:
+
+- `latest` _(String)_ - Latest version. 
+- `current` _(String)_ - Current version.
+- `type` _(String)_ - Type of current update. Possible values: `latest`, `major`, `minor`, `patch`, `prerelease`, `build`.
+- `name` _(String)_ - Package name.
 
 ### notifier.notify([options])
 

--- a/readme.md
+++ b/readme.md
@@ -124,12 +124,6 @@ Default: `1000 * 60 * 60 * 24` *(1 day)*
 
 How often to check for updates.
 
-#### callback(error, update)
-
-Type: `Function`
-
-Passing a callback here will make it check for an update directly and report right away. Not recommended as you won't get the benefits explained in [`How`](#how). `update` is equal to `notifier.update`.
-
 #### shouldNotifyInNpmScript
 
 Type: `boolean`<br>
@@ -143,6 +137,10 @@ Type: `string`<br>
 Default: `latest`
 
 Which [dist-tag](https://docs.npmjs.com/adding-dist-tags-to-packages) to use to find the latest version.
+
+### notifier.getSemverDiff()
+
+Get semver difference directly. This method will not trigger the checking process.
 
 ### notifier.notify([options])
 

--- a/readme.md
+++ b/readme.md
@@ -138,13 +138,13 @@ Default: `latest`
 
 Which [dist-tag](https://docs.npmjs.com/adding-dist-tags-to-packages) to use to find the latest version.
 
-### notifier.checkImmediately()
+### notifier.fetchInfo()
 
-Check update immediately. This method will not trigger the checking process.
+Check update information.
 
 Returns an `object` with:
 
-- `latest` _(String)_ - Latest version. 
+- `latest` _(String)_ - Latest version.
 - `current` _(String)_ - Current version.
 - `type` _(String)_ - Type of current update. Possible values: `latest`, `major`, `minor`, `patch`, `prerelease`, `build`.
 - `name` _(String)_ - Package name.

--- a/test/update-notifier.js
+++ b/test/update-notifier.js
@@ -33,13 +33,14 @@ test.afterEach(() => {
 	}, 10000);
 });
 
-test('get semver diff', async t => {
-	const update = await updateNotifier(generateSettings()).getSemverDiff();
+test('check immediately', async t => {
+	const update = await updateNotifier(generateSettings()).checkImmediately();
+	console.log(update);
 	t.is(update.latest, '0.0.2');
 });
 
-test('get semver diff with dist-tag', async t => {
-	const update = await updateNotifier(generateSettings({distTag: '0.0.3-rc1'})).getSemverDiff();
+test('check immeditely with dist-tag', async t => {
+	const update = await updateNotifier(generateSettings({distTag: '0.0.3-rc1'})).checkImmediately();
 	t.is(update.latest, '0.0.3-rc1');
 });
 

--- a/test/update-notifier.js
+++ b/test/update-notifier.js
@@ -33,14 +33,14 @@ test.afterEach(() => {
 	}, 10000);
 });
 
-test('check immediately', async t => {
-	const update = await updateNotifier(generateSettings()).checkImmediately();
+test('fetch info', async t => {
+	const update = await updateNotifier(generateSettings()).fetchInfo();
 	console.log(update);
 	t.is(update.latest, '0.0.2');
 });
 
-test('check immeditely with dist-tag', async t => {
-	const update = await updateNotifier(generateSettings({distTag: '0.0.3-rc1'})).checkImmediately();
+test('fetch info with dist-tag', async t => {
+	const update = await updateNotifier(generateSettings({distTag: '0.0.3-rc1'})).fetchInfo();
 	t.is(update.latest, '0.0.3-rc1');
 });
 

--- a/test/update-notifier.js
+++ b/test/update-notifier.js
@@ -13,7 +13,6 @@ const generateSettings = (options = {}) => {
 			name: 'update-notifier-tester',
 			version: '0.0.2'
 		},
-		callback: options.callback,
 		distTag: options.distTag
 	};
 };
@@ -42,17 +41,6 @@ test('check for update', async t => {
 test('check for update with dist-tag', async t => {
 	const update = await updateNotifier(generateSettings({distTag: '0.0.3-rc1'})).checkNpm();
 	t.is(update.latest, '0.0.3-rc1');
-});
-
-test.cb('check for update with callback', t => {
-	t.plan(1);
-
-	updateNotifier(generateSettings({
-		callback: () => {
-			t.pass();
-			t.end();
-		}
-	}));
 });
 
 test('don\'t initialize configStore when NO_UPDATE_NOTIFIER is set', t => {

--- a/test/update-notifier.js
+++ b/test/update-notifier.js
@@ -33,13 +33,13 @@ test.afterEach(() => {
 	}, 10000);
 });
 
-test('check for update', async t => {
-	const update = await updateNotifier(generateSettings()).checkNpm();
+test('get semver diff', async t => {
+	const update = await updateNotifier(generateSettings()).getSemverDiff();
 	t.is(update.latest, '0.0.2');
 });
 
-test('check for update with dist-tag', async t => {
-	const update = await updateNotifier(generateSettings({distTag: '0.0.3-rc1'})).checkNpm();
+test('get semver diff with dist-tag', async t => {
+	const update = await updateNotifier(generateSettings({distTag: '0.0.3-rc1'})).getSemverDiff();
 	t.is(update.latest, '0.0.3-rc1');
 });
 


### PR DESCRIPTION
Just deprecate the `callback` option as https://github.com/yeoman/update-notifier/issues/85#issuecomment-279421079 mentioned.

It's a breaking change.