### PR TITLE
Allow to specify, or detect, the registry URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ class UpdateNotifier {
 		this.options = options;
 		options.pkg = options.pkg || {};
 		options.distTag = options.distTag || 'latest';
+		options.registryUrl = options.registryUrl || ((options.pkg.publishConfig) && options.pkg.publishConfig.registry);
 
 		// Reduce pkg to the essential keys. with fallback to deprecated options
 		// TODO: Remove deprecated options at some point far into the future
@@ -109,8 +110,8 @@ class UpdateNotifier {
 	}
 
 	async checkNpm() {
-		const {distTag} = this.options;
-		const latest = await latestVersion()(this.packageName, {version: distTag});
+		const {distTag, registryUrl} = this.options;
+		const latest = await latestVersion()(this.packageName, {registryUrl, version: distTag});
 
 		return {
 			latest,


### PR DESCRIPTION
When working with a private NPM registry, we need to be able to specify the registry URL for the version check.
If the target environment is using Yarn and not NPM, the registry-url module won't detect a configured (and/or scoped) custom registry.
This PR uses the options.registryUrl property or, if it's defined, the pkg.publishConfig.registry property. If neither of the two are defined, the registryUrl detection is handled by the registry-url module.