### PR TITLE
Docs: Update URL to 'TTY' 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,7 +135,7 @@ Which [dist-tag](https://docs.npmjs.com/adding-dist-tags-to-packages) to use to 
 
 Convenience method to display a notification message. *(See screenshot)*
 
-Only notifies if there is an update and the process is [TTY](https://nodejs.org/api/process.html#process_tty_terminals_and_process_stdout).
+Only notifies if there is an update and the process is [TTY](https://nodejs.org/api/process.html#process_a_note_on_process_i_o).
 
 #### options
 


### PR DESCRIPTION
Updates the [doc's external link](https://github.com/yeoman/update-notifier/blob/master/readme.md#notifiernotifyoptions) to nodejs website on TTY context to match their current section title, changed in [this commit](https://github.com/nodejs/node/commit/5ba00af2170e58e29ac985038b335253fdd39d9f?short_path=3025128#diff-eaa7a086b3a1bc26c044f11e69800239L1571).