### PR TITLE
Remove object spread to support node >=8.0.0 <8.6.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,11 +126,10 @@ class UpdateNotifier {
 			return this;
 		}
 
-		options = {
+		options = Object.assign({
 			isGlobal: isInstalledGlobally(),
-			isYarnGlobal: isYarnGlobal()(),
-			...options
-		};
+			isYarnGlobal: isYarnGlobal()()
+		}, options);
 
 		let installCommand;
 

--- a/package.json
+++ b/package.json
@@ -53,5 +53,10 @@
 		"mock-require": "^3.0.3",
 		"strip-ansi": "^5.2.0",
 		"xo": "^0.24.0"
+	},
+	"xo": {
+		"rules": {
+			"prefer-object-spread": 0
+		}
 	}
 }


### PR DESCRIPTION
Low priority fix: Change object spread back to `Object.assign` since engine.node is >=8.

Another package on node 8 dependent on update-notifier was failing at the `notify()` script with `Unexpected token ...` and not showing their "please upgrade node" warning. [Node>=8.6 compiled ok](https://node.green/#ES2018-features-object-rest-spread-properties-object-spread-properties), but everything below that resulted in the same error. Was going to open an issue there and PR, but decided just to PR here because there's only one instance of the object spreading and seemed like a better fix in case any other users were using lower 8x versions.

xo default rule is "error" on `prefer-object-spread` (which I'm sure you're aware as a member), so I turned that rule off in package.json to complete the tests. I left the warn "no warning comments" alone.