### PR TITLE
Disable when `NODE_ENV` is `test`

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ class UpdateNotifier {
 		this.hasCallback = typeof options.callback === 'function';
 		this.callback = options.callback || (() => {});
 		this.disabled = 'NO_UPDATE_NOTIFIER' in process.env ||
+			process.env.NODE_ENV === 'test' ||
 			process.argv.includes('--no-update-notifier') ||
 			isCi();
 		this.shouldNotifyInNpmScript = options.shouldNotifyInNpmScript;

--- a/readme.md
+++ b/readme.md
@@ -176,7 +176,9 @@ Users of your module have the ability to opt-out of the update notifier by chang
 
 Users can also opt-out by [setting the environment variable](https://github.com/sindresorhus/guides/blob/master/set-environment-variables.md) `NO_UPDATE_NOTIFIER` with any value or by using the `--no-update-notifier` flag on a per run basis.
 
-The check is also skipped on CI automatically.
+The check is also skipped automatically:
+  - on CI
+  - in unit tests (when the `NODE_ENV` environment variable is `test`)
 
 
 ## About

--- a/test/update-notifier.js
+++ b/test/update-notifier.js
@@ -22,6 +22,9 @@ let argv;
 let configstorePath;
 
 test.beforeEach(() => {
+	// Prevents NODE_ENV 'test' default behavior which disables `update-notifier`
+	process.env.NODE_ENV = 'ava-test';
+
 	argv = process.argv.slice();
 	configstorePath = updateNotifier(generateSettings()).config.path;
 });
@@ -63,6 +66,12 @@ test('don\'t initialize configStore when NO_UPDATE_NOTIFIER is set', t => {
 
 test('don\'t initialize configStore when --no-update-notifier is set', t => {
 	process.argv.push('--no-update-notifier');
+	const notifier = updateNotifier(generateSettings());
+	t.is(notifier.config, undefined);
+});
+
+test('don\'t initialize configStore when NODE_ENV === "test"', t => {
+	process.env.NODE_ENV = 'test';
 	const notifier = updateNotifier(generateSettings());
 	t.is(notifier.config, undefined);
 });


### PR DESCRIPTION
Fixes #171.

This disables `update-notifier` when the `NODE_ENV` environment variable is `test`, for example during unit tests.