### PR TITLE
Avoid showing notification if current version is the latest

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,10 @@ class UpdateNotifier {
 		this.update = this.config.get('update');
 
 		if (this.update) {
+			// Use the real latest version instead of the cached one
+			this.update.current = this.packageVersion;
+
+			// Clear cached information
 			this.config.delete('update');
 		}
 
@@ -122,7 +126,7 @@ class UpdateNotifier {
 
 	notify(options) {
 		const suppressForNpm = !this.shouldNotifyInNpmScript && isNpm().isNpm;
-		if (!process.stdout.isTTY || suppressForNpm || !this.update || this.update.latest === this.packageVersion) {
+		if (!process.stdout.isTTY || suppressForNpm || !this.update) {
 			return this;
 		}
 

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ class UpdateNotifier {
 
 	notify(options) {
 		const suppressForNpm = !this.shouldNotifyInNpmScript && isNpm().isNpm;
-		if (!process.stdout.isTTY || suppressForNpm || !this.update) {
+		if (!process.stdout.isTTY || suppressForNpm || !this.update || this.update.latest === this.packageVersion) {
 			return this;
 		}
 

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ class UpdateNotifier {
 
 	notify(options) {
 		const suppressForNpm = !this.shouldNotifyInNpmScript && isNpm().isNpm;
-		if (!process.stdout.isTTY || suppressForNpm || !this.update) {
+		if (!process.stdout.isTTY || suppressForNpm || !this.update || this.update.current === this.update.latest) {
 			return this;
 		}
 

--- a/test/notify.js
+++ b/test/notify.js
@@ -83,3 +83,11 @@ test('should ouput if running as npm script and shouldNotifyInNpmScript option s
 	notifier.notify({defer: false});
 	t.true(stripAnsi(errorLogs).includes('Update available'));
 });
+
+test('should not output if current version is the latest', t => {
+	setupTest(true);
+	const notifier = new Control(true);
+	notifier.packageVersion = '1.0.0';
+	notifier.notify({defer: false});
+	t.false(stripAnsi(errorLogs).includes('Update available'));
+});

--- a/test/notify.js
+++ b/test/notify.js
@@ -87,7 +87,7 @@ test('should ouput if running as npm script and shouldNotifyInNpmScript option s
 test('should not output if current version is the latest', t => {
 	setupTest(true);
 	const notifier = new Control(true);
-	notifier.packageVersion = '1.0.0';
+	notifier.update.current = '1.0.0';
 	notifier.notify({defer: false});
 	t.false(stripAnsi(errorLogs).includes('Update available'));
 });


### PR DESCRIPTION
Fixes https://github.com/yeoman/update-notifier/issues/60

That bug exists because `update-notifier` caches the current version on first run and then notifies about it on the following one, without checking again which version is currently installed.

This PR now also fixes the value returned as `notifier.update.current`, which was previously just the cached version rather than the real current version (_real_ => from the currently-installed `package.json`)


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#60: When run right after npm install, a wrong version is displayed](https://issuehunt.io/repos/7069389/issues/60)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->