### PR TITLE
Improve vertical alignment of the notifier output

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ class UpdateNotifier {
 					chalk().cyan(format(' sudo chown -R $USER:$(id -gn $USER) %s ', xdgBasedir().config));
 
 				process.on('exit', () => {
-					console.error('\n' + boxen()(message, {align: 'center'}));
+					console.error(boxen()(message, {align: 'center'}));
 				});
 			}
 		}
@@ -151,7 +151,7 @@ class UpdateNotifier {
 			borderStyle: 'round'
 		};
 
-		const message = '\n' + boxen()(
+		const message = boxen()(
 			pupa()(template, {
 				packageName: this.packageName,
 				currentVersion: this.update.current,

--- a/test/notify.js
+++ b/test/notify.js
@@ -47,7 +47,6 @@ test('use pretty boxen message by default', t => {
 	notifier.notify({defer: false, isGlobal: true});
 
 	t.is(stripAnsi(errorLogs), `
-
    ╭───────────────────────────────────────────────────╮
    │                                                   │
    │          Update available 0.0.2 → 1.0.0           │
@@ -83,7 +82,6 @@ test('supports message with placeholders', t => {
 	});
 
 	t.is(stripAnsi(errorLogs), `
-
    ╭─────────────────────────────────────────────────────╮
    │                                                     │
    │        Package Name: update-notifier-tester         │


### PR DESCRIPTION
&nbsp; | Before | After
--- | --- | ---
`defer: true` (default) | <img width="318" alt="Screen Shot 2020-07-24 at 2 28 07 AM" src="https://user-images.githubusercontent.com/113730/88366023-eb311c80-cd55-11ea-9bee-1cc32ee949c2.png"> | <img width="331" alt="Screen Shot 2020-07-24 at 2 28 54 AM" src="https://user-images.githubusercontent.com/113730/88366041-fa17cf00-cd55-11ea-8402-cbd938c43471.png">
`defer: false` | <img width="322" alt="Screen Shot 2020-07-24 at 2 28 33 AM" src="https://user-images.githubusercontent.com/113730/88366029-f1bf9400-cd55-11ea-8e02-9a9bcbac3661.png"> | <img width="328" alt="Screen Shot 2020-07-24 at 2 29 17 AM" src="https://user-images.githubusercontent.com/113730/88366057-03a13700-cd56-11ea-8a3b-1263328a6c27.png">

Interestingly, while it doesn't feel that way on the screenshots, the current `defer: false` version is the weirdest, as it currently outputs 2 empty lines (1 by `\n` and 1 by the boxen margin)  before and 1 empty line after.
I started by tweaking the margins in weird ways, but then figured this could be improved upstream.
Does this change seem unreasonable?