### PR TITLE
Allow overriding individual Boxen options

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,12 +143,13 @@ class UpdateNotifier {
 
 		const template = options.message || defaultTemplate;
 
-		options.boxenOptions = options.boxenOptions || {
+		options.boxenOptions = {
 			padding: 1,
 			margin: 1,
 			align: 'center',
 			borderColor: 'yellow',
-			borderStyle: 'round'
+			borderStyle: 'round',
+			...(options.boxenOptions || {})
 		};
 
 		const message = '\n' + boxen()(


### PR DESCRIPTION
This means that:

```js
boxenOptions: {
  borderColor: 'yellow',
},
```

will now _only_ override `borderColor` while keeping the other defaults intact. Before this, updating one option meant all other defaults had to be passed again.