### PR TITLE
Added git-repo support for packages not on npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const boxen = importLazy('boxen');
 const xdgBasedir = importLazy('xdg-basedir');
 const isCi = importLazy('is-ci');
 const pupa = importLazy('pupa');
-const gitVersionTag = importLazy('git-version-tag');
+const gitVersionTag = require('git-version-tag');
 
 
 const ONE_DAY = 1000 * 60 * 60 * 24;
@@ -26,7 +26,7 @@ class UpdateNotifier {
 		this.options = options;
 		options.pkg = options.pkg || {};
 		options.distTag = options.distTag || 'latest';
-		options.repoUrl = options.repoUrl || null
+		options.remoteUrl = options.remoteUrl || null
 
 		// Reduce pkg to the essential keys. with fallback to deprecated options
 		// TODO: Remove deprecated options at some point far into the future
@@ -106,10 +106,12 @@ class UpdateNotifier {
 	async fetchInfo() {
 		const {distTag} = this.options;
 		let latest;
-		if(this.options.repoUrl) {
+		if(this.options.remoteUrl) {
+			console.log('this.options.remoteUrl',this.options.remoteUrl);
 			// git approach - for packages not published on npm
-			latest = await gitVersionTag(this.options.repoUrl, {getLatest:true})
+			latest = await gitVersionTag(this.options.remoteUrl, {getLatest:true});
 		} else {
+			console.log('latestVersion',this.options.remoteUrl);
 			// npm approach
 			latest = await latestVersion()(this.packageName, {version: distTag});
 		}

--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ const boxen = importLazy('boxen');
 const xdgBasedir = importLazy('xdg-basedir');
 const isCi = importLazy('is-ci');
 const pupa = importLazy('pupa');
+const gitVersionTag = importLazy('git-version-tag');
+
 
 const ONE_DAY = 1000 * 60 * 60 * 24;
 
@@ -24,6 +26,7 @@ class UpdateNotifier {
 		this.options = options;
 		options.pkg = options.pkg || {};
 		options.distTag = options.distTag || 'latest';
+		options.repoUrl = options.repoUrl || null
 
 		// Reduce pkg to the essential keys. with fallback to deprecated options
 		// TODO: Remove deprecated options at some point far into the future
@@ -102,8 +105,14 @@ class UpdateNotifier {
 
 	async fetchInfo() {
 		const {distTag} = this.options;
-		const latest = await latestVersion()(this.packageName, {version: distTag});
-
+		let latest;
+		if(this.options.repoUrl) {
+			// git approach - for packages not published on npm
+			latest = await gitVersionTag(this.options.repoUrl, {getLatest:true})
+		} else {
+			// npm approach
+			latest = await latestVersion()(this.packageName, {version: distTag});
+		}
 		return {
 			latest,
 			current: this.packageVersion,

--- a/index.js
+++ b/index.js
@@ -138,11 +138,15 @@ class UpdateNotifier {
 
 		if (options.isYarnGlobal) {
 			installCommand = `yarn global add ${this.packageName}`;
+		} else if (options.isGlobal && this.options.remoteUrl) {
+			installCommand = `npm update -g ${this.packageName}`;
 		} else if (options.isGlobal) {
 			installCommand = `npm i -g ${this.packageName}`;
 		} else if (hasYarn()()) {
 			installCommand = `yarn add ${this.packageName}`;
-		} else {
+		} else if(this.options.remoteUrl){
+			installCommand = `npm update ${this.packageName}`;
+		} else{
 			installCommand = `npm i ${this.packageName}`;
 		}
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"boxen": "^4.2.0",
 		"chalk": "^3.0.0",
 		"configstore": "^5.0.1",
-		"git-version-tag": "^1.0.1",
+		"git-version-tag": "^1.0.2",
 		"has-yarn": "^2.1.0",
 		"import-lazy": "^2.1.0",
 		"is-ci": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"boxen": "^4.2.0",
 		"chalk": "^3.0.0",
 		"configstore": "^5.0.1",
+		"git-version-tag": "^1.0.1",
 		"has-yarn": "^2.1.0",
 		"import-lazy": "^2.1.0",
 		"is-ci": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -86,35 +86,35 @@ Checks if there is an available update. Accepts options defined below. Returns a
 
 Type: `object`
 
-#### pkg
+#### options.pkg
 
 Type: `object`
 
-##### name
+##### options.pkg.name
 
 *Required*\
 Type: `string`
 
-##### version
+##### options.pkg.version
 
 *Required*\
 Type: `string`
 
-#### updateCheckInterval
+#### options.updateCheckInterval
 
 Type: `number`\
 Default: `1000 * 60 * 60 * 24` *(1 day)*
 
 How often to check for updates.
 
-#### shouldNotifyInNpmScript
+#### options.shouldNotifyInNpmScript
 
 Type: `boolean`\
 Default: `false`
 
 Allows notification to be shown when running as an npm script.
 
-#### distTag
+#### options.distTag
 
 Type: `string`\
 Default: `'latest'`
@@ -142,14 +142,14 @@ Only notifies if there is an update and the process is [TTY](https://nodejs.org/
 
 Type: `object`
 
-##### defer
+##### options.defer
 
 Type: `boolean`\
 Default: `true`
 
 Defer showing the notification to after the process has exited.
 
-##### message
+##### options.message
 
 Type: `string`\
 Default: [See above screenshot](https://github.com/yeoman/update-notifier#update-notifier-)
@@ -170,19 +170,26 @@ notifier.notify({message: 'Run `{updateCommand}` to update.'});
 // Run `npm install update-notifier-tester@1.0.0` to update.
 ```
 
-##### isGlobal
+##### options.isGlobal
 
 Type: `boolean`\
 Default: Auto-detect
 
 Include the `-g` argument in the default message's `npm i` recommendation. You may want to change this if your CLI package can be installed as a dependency of another project, and don't want to recommend a global installation. This option is ignored if you supply your own `message` (see above).
 
-##### boxenOptions
+##### options.boxenOptions
 
 Type: `object`\
 Default: `{padding: 1, margin: 1, align: 'center', borderColor: 'yellow', borderStyle: 'round'}` *(See screenshot)*
 
 Options object that will be passed to [`boxen`](https://github.com/sindresorhus/boxen).
+
+##### options.remoteUrl
+
+Type: `String`\
+Default: `null`
+
+If your package is not published on NPM but instead only resides on a Git repo (e.g. GitHub, Gitlab, Bitbucket).
 
 ### User settings
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Inform users of your package of updates in a non-intrusive way.
 
 ## Install
 
-```
+```bash
 $ npm install update-notifier
 ```
 

--- a/test/git-test.js
+++ b/test/git-test.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const updateNotifier = require('../index.js');
+
+test();
+
+async function test() {
+	const testRemoteUri = 'https://github.com/yeoman/update-notifier.git';
+
+
+	const notifier = updateNotifier({
+		pkg: {
+			name: 'update-notifier',
+			version: '0.9.0'
+		},
+		updateCheckInterval: 1000,
+		remoteUrl: testRemoteUri,
+	});
+	// Notify using the built-in convenience method
+	notifier.notify();
+	// console.log('test:notifier.update', notifier.update);
+
+}


### PR DESCRIPTION
for issue #188 
**features**
- added new dependency to my library git-version-tag (full support for GitHub, Bitbucket, GitLab)
- added new constructor option "remoteUrl" to specify the git repo-url
- auto-switching the printed command from install to "update" of install command for git-based packages
- Docs: made options more easily readable (using header tags alone doesn't really let you see where things belong to with the current GitHub styles)