### PR TITLE
Added git-repo support for packages not on npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const boxen = importLazy('boxen');
 const xdgBasedir = importLazy('xdg-basedir');
 const isCi = importLazy('is-ci');
 const pupa = importLazy('pupa');
-const gitVersionTag = importLazy('git-version-tag');
+const gitVersionTag = require('git-version-tag');
 
 
 const ONE_DAY = 1000 * 60 * 60 * 24;
@@ -26,7 +26,7 @@ class UpdateNotifier {
 		this.options = options;
 		options.pkg = options.pkg || {};
 		options.distTag = options.distTag || 'latest';
-		options.repoUrl = options.repoUrl || null
+		options.remoteUrl = options.remoteUrl || null
 
 		// Reduce pkg to the essential keys. with fallback to deprecated options
 		// TODO: Remove deprecated options at some point far into the future
@@ -106,10 +106,12 @@ class UpdateNotifier {
 	async fetchInfo() {
 		const {distTag} = this.options;
 		let latest;
-		if(this.options.repoUrl) {
+		if(this.options.remoteUrl) {
+			console.log('this.options.remoteUrl',this.options.remoteUrl);
 			// git approach - for packages not published on npm
-			latest = await gitVersionTag(this.options.repoUrl, {getLatest:true})
+			latest = await gitVersionTag(this.options.remoteUrl, {getLatest:true});
 		} else {
+			console.log('latestVersion',this.options.remoteUrl);
 			// npm approach
 			latest = await latestVersion()(this.packageName, {version: distTag});
 		}

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ class UpdateNotifier {
 		let latest;
 		if (this.options.remoteUrl) {
 			// Git approach - for packages not published on npm
-			latest = await gitVersionTag(this.options.remoteUrl, {getLatest:true});
+			latest = await gitVersionTag(this.options.remoteUrl, {getLatest: true});
 		} else {
 			// Npm approach
 			latest = await latestVersion()(this.packageName, {version: distTag});

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const chalk = importLazy('chalk');
 const semverDiff = importLazy('semver-diff');
 const latestVersion = importLazy('latest-version');
 const isNpm = importLazy('is-npm');
-const isInstalledGlobally = importLazy('is-installed-globally');
 const isYarnGlobal = importLazy('is-yarn-global');
 const hasYarn = importLazy('has-yarn');
 const boxen = importLazy('boxen');
@@ -17,8 +16,14 @@ const xdgBasedir = importLazy('xdg-basedir');
 const isCi = importLazy('is-ci');
 const pupa = importLazy('pupa');
 const gitVersionTag = require('git-version-tag');
+const execSync = require('child_process').execSync;
 
+const isNpmGlobal = function () {
+	const globalNpmRepos = execSync('npm root --global').toString().trim();
+	return __dirname.startsWith(globalNpmRepos);
+};
 const ONE_DAY = 1000 * 60 * 60 * 24;
+
 
 class UpdateNotifier {
 	constructor(options = {}) {
@@ -128,7 +133,7 @@ class UpdateNotifier {
 		}
 
 		options = Object.assign({
-			isGlobal: isInstalledGlobally(),
+			isGlobal: isNpmGlobal(),
 			isYarnGlobal: isYarnGlobal()()
 		}, options);
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ const boxen = importLazy('boxen');
 const xdgBasedir = importLazy('xdg-basedir');
 const isCi = importLazy('is-ci');
 const pupa = importLazy('pupa');
+const gitVersionTag = importLazy('git-version-tag');
+
 
 const ONE_DAY = 1000 * 60 * 60 * 24;
 
@@ -24,6 +26,7 @@ class UpdateNotifier {
 		this.options = options;
 		options.pkg = options.pkg || {};
 		options.distTag = options.distTag || 'latest';
+		options.repoUrl = options.repoUrl || null
 
 		// Reduce pkg to the essential keys. with fallback to deprecated options
 		// TODO: Remove deprecated options at some point far into the future
@@ -102,8 +105,14 @@ class UpdateNotifier {
 
 	async fetchInfo() {
 		const {distTag} = this.options;
-		const latest = await latestVersion()(this.packageName, {version: distTag});
-
+		let latest;
+		if(this.options.repoUrl) {
+			// git approach - for packages not published on npm
+			latest = await gitVersionTag(this.options.repoUrl, {getLatest:true})
+		} else {
+			// npm approach
+			latest = await latestVersion()(this.packageName, {version: distTag});
+		}
 		return {
 			latest,
 			current: this.packageVersion,

--- a/index.js
+++ b/index.js
@@ -138,11 +138,15 @@ class UpdateNotifier {
 
 		if (options.isYarnGlobal) {
 			installCommand = `yarn global add ${this.packageName}`;
+		} else if (options.isGlobal && this.options.remoteUrl) {
+			installCommand = `npm update -g ${this.packageName}`;
 		} else if (options.isGlobal) {
 			installCommand = `npm i -g ${this.packageName}`;
 		} else if (hasYarn()()) {
 			installCommand = `yarn add ${this.packageName}`;
-		} else {
+		} else if(this.options.remoteUrl){
+			installCommand = `npm update ${this.packageName}`;
+		} else{
 			installCommand = `npm i ${this.packageName}`;
 		}
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ const isCi = importLazy('is-ci');
 const pupa = importLazy('pupa');
 const gitVersionTag = require('git-version-tag');
 
-
 const ONE_DAY = 1000 * 60 * 60 * 24;
 
 class UpdateNotifier {
@@ -26,7 +25,7 @@ class UpdateNotifier {
 		this.options = options;
 		options.pkg = options.pkg || {};
 		options.distTag = options.distTag || 'latest';
-		options.remoteUrl = options.remoteUrl || null
+		options.remoteUrl = options.remoteUrl || null;
 
 		// Reduce pkg to the essential keys. with fallback to deprecated options
 		// TODO: Remove deprecated options at some point far into the future
@@ -106,15 +105,14 @@ class UpdateNotifier {
 	async fetchInfo() {
 		const {distTag} = this.options;
 		let latest;
-		if(this.options.remoteUrl) {
-			console.log('this.options.remoteUrl',this.options.remoteUrl);
-			// git approach - for packages not published on npm
+		if (this.options.remoteUrl) {
+			// Git approach - for packages not published on npm
 			latest = await gitVersionTag(this.options.remoteUrl, {getLatest:true});
 		} else {
-			console.log('latestVersion',this.options.remoteUrl);
-			// npm approach
+			// Npm approach
 			latest = await latestVersion()(this.packageName, {version: distTag});
 		}
+
 		return {
 			latest,
 			current: this.packageVersion,
@@ -144,9 +142,9 @@ class UpdateNotifier {
 			installCommand = `npm i -g ${this.packageName}`;
 		} else if (hasYarn()()) {
 			installCommand = `yarn add ${this.packageName}`;
-		} else if(this.options.remoteUrl){
+		} else if (this.options.remoteUrl) {
 			installCommand = `npm update ${this.packageName}`;
-		} else{
+		} else {
 			installCommand = `npm i ${this.packageName}`;
 		}
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"boxen": "^4.2.0",
 		"chalk": "^3.0.0",
 		"configstore": "^5.0.1",
-		"git-version-tag": "^1.0.1",
+		"git-version-tag": "^1.0.2",
 		"has-yarn": "^2.1.0",
 		"import-lazy": "^2.1.0",
 		"is-ci": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"boxen": "^4.2.0",
 		"chalk": "^3.0.0",
 		"configstore": "^5.0.1",
+		"git-version-tag": "^1.0.1",
 		"has-yarn": "^2.1.0",
 		"import-lazy": "^2.1.0",
 		"is-ci": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -86,35 +86,35 @@ Checks if there is an available update. Accepts options defined below. Returns a
 
 Type: `object`
 
-#### pkg
+#### options.pkg
 
 Type: `object`
 
-##### name
+##### options.pkg.name
 
 *Required*\
 Type: `string`
 
-##### version
+##### options.pkg.version
 
 *Required*\
 Type: `string`
 
-#### updateCheckInterval
+#### options.updateCheckInterval
 
 Type: `number`\
 Default: `1000 * 60 * 60 * 24` *(1 day)*
 
 How often to check for updates.
 
-#### shouldNotifyInNpmScript
+#### options.shouldNotifyInNpmScript
 
 Type: `boolean`\
 Default: `false`
 
 Allows notification to be shown when running as an npm script.
 
-#### distTag
+#### options.distTag
 
 Type: `string`\
 Default: `'latest'`
@@ -142,14 +142,14 @@ Only notifies if there is an update and the process is [TTY](https://nodejs.org/
 
 Type: `object`
 
-##### defer
+##### options.defer
 
 Type: `boolean`\
 Default: `true`
 
 Defer showing the notification to after the process has exited.
 
-##### message
+##### options.message
 
 Type: `string`\
 Default: [See above screenshot](https://github.com/yeoman/update-notifier#update-notifier-)
@@ -170,19 +170,26 @@ notifier.notify({message: 'Run `{updateCommand}` to update.'});
 // Run `npm install update-notifier-tester@1.0.0` to update.
 ```
 
-##### isGlobal
+##### options.isGlobal
 
 Type: `boolean`\
 Default: Auto-detect
 
 Include the `-g` argument in the default message's `npm i` recommendation. You may want to change this if your CLI package can be installed as a dependency of another project, and don't want to recommend a global installation. This option is ignored if you supply your own `message` (see above).
 
-##### boxenOptions
+##### options.boxenOptions
 
 Type: `object`\
 Default: `{padding: 1, margin: 1, align: 'center', borderColor: 'yellow', borderStyle: 'round'}` *(See screenshot)*
 
 Options object that will be passed to [`boxen`](https://github.com/sindresorhus/boxen).
+
+##### options.remoteUrl
+
+Type: `String`\
+Default: `null`
+
+If your package is not published on NPM but instead only resides on a Git repo (e.g. GitHub, Gitlab, Bitbucket).
 
 ### User settings
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Inform users of your package of updates in a non-intrusive way.
 
 ## Install
 
-```
+```bash
 $ npm install update-notifier
 ```
 

--- a/test/git-test.js
+++ b/test/git-test.js
@@ -6,17 +6,16 @@ test();
 async function test() {
 	const testRemoteUri = 'https://github.com/yeoman/update-notifier.git';
 
-
 	const notifier = updateNotifier({
 		pkg: {
 			name: 'update-notifier',
 			version: '0.9.0'
 		},
 		updateCheckInterval: 1000,
-		remoteUrl: testRemoteUri,
+		remoteUrl: testRemoteUri
 	});
 	// Notify using the built-in convenience method
 	notifier.notify();
-	// console.log('test:notifier.update', notifier.update);
+	console.log('test:notifier.update', notifier.update);
 
 }

--- a/test/git-test.js
+++ b/test/git-test.js
@@ -17,5 +17,4 @@ async function test() {
 	// Notify using the built-in convenience method
 	notifier.notify();
 	console.log('test:notifier.update', notifier.update);
-
 }

--- a/test/git-test.js
+++ b/test/git-test.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const updateNotifier = require('../index.js');
+
+test();
+
+async function test() {
+	const testRemoteUri = 'https://github.com/yeoman/update-notifier.git';
+
+
+	const notifier = updateNotifier({
+		pkg: {
+			name: 'update-notifier',
+			version: '0.9.0'
+		},
+		updateCheckInterval: 1000,
+		remoteUrl: testRemoteUri,
+	});
+	// Notify using the built-in convenience method
+	notifier.notify();
+	// console.log('test:notifier.update', notifier.update);
+
+}

--- a/test/git-test.js
+++ b/test/git-test.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const updateNotifier = require('../index.js');
+const updateNotifier = require('..');
 
 test();
 


### PR DESCRIPTION
for issue #186 
**features**
- added new dependency to my library git-version-tag (full support for GitHub, Bitbucket, GitLab)
- added new constructor option "remoteUrl" to specify the git repo-url
- auto-switching the printed command from install to "update" of install command for git-based packages
- Docs: made options more easily readable (using header tags alone doesn't really let you see where things belong to with the current GitHub styles)