### PR TITLE
Update `boxen` to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"version"
 	],
 	"dependencies": {
-		"boxen": "^4.2.0",
+		"boxen": "^5.0.0",
 		"chalk": "^4.1.0",
 		"configstore": "^5.0.1",
 		"has-yarn": "^2.1.0",


### PR DESCRIPTION
Update the `boxen` package to pick up fixes for TypeScript users. 

Following the merge of https://github.com/sindresorhus/boxen/pull/50 to make sure that TypeScript users get a consistent fix for the enum change `boxen` needs to be updated to pick up the latest major version change.