### PR TITLE
Bump 'latest-version' package to fix security vulnerability in subdependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"is-installed-globally": "^0.4.0",
 		"is-npm": "^6.0.0",
 		"is-yarn-global": "^0.4.0",
-		"latest-version": "^6.0.0",
+		"latest-version": "^7.0.0",
 		"pupa": "^3.1.0",
 		"semver": "^7.3.7",
 		"semver-diff": "^4.0.0",


### PR DESCRIPTION
Fix just released in v7.0.0 of latest-version, which no longer uses a package that then again depends in a vulnerable version of `got` package.

@sindresorhus Could you approve workflow run and merge when you have time? This package already requires Node 14, so we should be good2go.