### PR TITLE
switch to esmock, re #221

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"node": ">=14.16"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test-old": "xo && NODE_OPTIONS=--loader=esmock ava",
+		"test": "NODE_OPTIONS='--loader=esmock --no-warnings' ava test/notify"
 	},
 	"files": [
 		"index.js",
@@ -54,9 +55,8 @@
 	},
 	"devDependencies": {
 		"ava": "^4.3.0",
-		"clear-module": "^4.1.2",
 		"fixture-stdout": "^0.2.1",
-		"mock-require": "^3.0.3",
+		"esmock": "^1.7.8",
 		"strip-ansi": "^7.0.1",
 		"xo": "^0.50.0"
 	},

--- a/test/notify.js
+++ b/test/notify.js
@@ -1,10 +1,9 @@
 import process from 'node:process';
 import {inherits} from 'node:util';
-import clearModule from 'clear-module';
 import FixtureStdout from 'fixture-stdout';
 import stripAnsi from 'strip-ansi';
 import test from 'ava';
-import mock from 'mock-require';
+import esmock from 'esmock';
 
 const stderr = new FixtureStdout({
 	stream: process.stderr,
@@ -20,16 +19,12 @@ function Control(shouldNotifyInNpmScript) {
 }
 
 const setupTest = async isNpmReturnValue => {
-	for (const name of ['..', 'is-npm']) {
-		clearModule(name);
-	}
-
 	process.stdout.isTTY = true;
 
-	// TODO: Switch to https://github.com/iambumblehead/esmock
-	mock('is-npm', {isNpmOrYarn: isNpmReturnValue || false});
+	const UpdateNotifier = await esmock('../update-notifier.js', {
+		'is-npm': {isNpmOrYarn: isNpmReturnValue || false}
+	});
 
-	const {default: UpdateNotifier} = await import('../update-notifier.js');
 	inherits(Control, UpdateNotifier);
 };
 
@@ -45,12 +40,11 @@ test.beforeEach(async () => {
 });
 
 test.afterEach(() => {
-	mock.stopAll();
 	stderr.release();
 	errorLogs = '';
 });
 
-test.failing('use pretty boxen message by default', t => {
+test('use pretty boxen message by default', async t => {
 	const notifier = new Control();
 	notifier.notify({defer: false, isGlobal: true});
 
@@ -67,7 +61,7 @@ test.failing('use pretty boxen message by default', t => {
 `);
 });
 
-test.failing('supports custom message', t => {
+test('supports custom message', t => {
 	const notifier = new Control();
 	notifier.notify({
 		defer: false,
@@ -78,7 +72,7 @@ test.failing('supports custom message', t => {
 	t.true(stripAnsi(errorLogs).includes('custom message'));
 });
 
-test.failing('supports message with placeholders', t => {
+test('supports message with placeholders', t => {
 	const notifier = new Control();
 	notifier.notify({
 		defer: false,
@@ -104,42 +98,42 @@ test.failing('supports message with placeholders', t => {
 `);
 });
 
-test.failing('exclude -g argument when `isGlobal` option is `false`', t => {
+test('exclude -g argument when `isGlobal` option is `false`', t => {
 	const notifier = new Control();
 	notifier.notify({defer: false, isGlobal: false});
 	t.not(stripAnsi(errorLogs).indexOf('Run npm i update-notifier-tester to update'), -1);
 });
 
-test.failing('shouldNotifyInNpmScript should default to false', t => {
+test('shouldNotifyInNpmScript should default to false', t => {
 	const notifier = new Control();
 	notifier.notify({defer: false});
 	t.not(stripAnsi(errorLogs).indexOf('Update available'), -1);
 });
 
-test('suppress output when running as npm script', t => {
-	setupTest(true);
+test('suppress output when running as npm script', async t => {
+	await setupTest(true);
 	const notifier = new Control();
 	notifier.notify({defer: false});
 	t.false(stripAnsi(errorLogs).includes('Update available'));
 });
 
-test('should output if running as npm script and shouldNotifyInNpmScript option set', t => {
-	setupTest(true);
+test('should output if running as npm script and shouldNotifyInNpmScript option set', async t => {
+	await setupTest(true);
 	const notifier = new Control(true);
 	notifier.notify({defer: false});
 	t.true(stripAnsi(errorLogs).includes('Update available'));
 });
 
-test('should not output if current version is the latest', t => {
-	setupTest(true);
+test('should not output if current version is the latest', async t => {
+	await setupTest(true);
 	const notifier = new Control(true);
 	notifier.update.current = '1.0.0';
 	notifier.notify({defer: false});
 	t.false(stripAnsi(errorLogs).includes('Update available'));
 });
 
-test('should not output if current version is more recent than the reported latest', t => {
-	setupTest(true);
+test('should not output if current version is more recent than the reported latest', async t => {
+	await setupTest(true);
 	const notifier = new Control(true);
 	notifier.update.current = '1.0.1';
 	notifier.notify({defer: false});

--- a/test/update-notifier.js
+++ b/test/update-notifier.js
@@ -1,10 +1,7 @@
 import process from 'node:process';
 import fs from 'node:fs';
 import test from 'ava';
-import mockRequire from 'mock-require';
-import updateNotifier from '../index.js';
-
-mockRequire('is-ci', false);
+import esmock from 'esmock';
 
 const generateSettings = (options = {}) => ({
 	pkg: {
@@ -22,7 +19,6 @@ test.beforeEach(() => {
 	process.env.NODE_ENV = 'ava-test';
 
 	argv = [...process.argv];
-	configstorePath = updateNotifier(generateSettings()).config.path;
 });
 
 test.afterEach(() => {
@@ -34,30 +30,40 @@ test.afterEach(() => {
 });
 
 test('fetch info', async t => {
+	const updateNotifier = await esmock('../index.js', null, { 'is-ci': false });
+	configstorePath = updateNotifier(generateSettings()).config.path;
 	const update = await updateNotifier(generateSettings()).fetchInfo();
-	console.log(update);
+
 	t.is(update.latest, '0.0.2');
 });
 
 test('fetch info with dist-tag', async t => {
+	const updateNotifier = await esmock('../index.js', null, { 'is-ci': false });
+	configstorePath = updateNotifier(generateSettings()).config.path;
 	const update = await updateNotifier(generateSettings({distTag: '0.0.3-rc1'})).fetchInfo();
 	t.is(update.latest, '0.0.3-rc1');
 });
 
-test('don\'t initialize configStore when NO_UPDATE_NOTIFIER is set', t => {
+test('don\'t initialize configStore when NO_UPDATE_NOTIFIER is set', async t => {
+	const updateNotifier = await esmock('../index.js', null, { 'is-ci': false });
+	configstorePath = updateNotifier(generateSettings()).config.path;
 	process.env.NO_UPDATE_NOTIFIER = '1';
 	const notifier = updateNotifier(generateSettings());
 	t.is(notifier.config, undefined);
 });
 
-test('don\'t initialize configStore when --no-update-notifier is set', t => {
+test('don\'t initialize configStore when --no-update-notifier is set', async t => {
+	const updateNotifier = await esmock('../index.js', null, { 'is-ci': false });
+	configstorePath = updateNotifier(generateSettings()).config.path;
 	process.argv.push('--no-update-notifier');
 	const notifier = updateNotifier(generateSettings());
 	t.is(notifier.config, undefined);
 });
 
-test('don\'t initialize configStore when NODE_ENV === "test"', t => {
+test('don\'t initialize configStore when NODE_ENV === "test"', async t => {
 	process.env.NODE_ENV = 'test';
+	const updateNotifier = await esmock('../index.js', null, { 'is-ci': false });
 	const notifier = updateNotifier(generateSettings());
 	t.is(notifier.config, undefined);
+	t.true( true );
 });


### PR DESCRIPTION
related https://github.com/yeoman/update-notifier/issues/221

I hope the changes here are OK and wanted to mention two things. One thing, some tests, expected to fail, were passing in my local environment. I found this [this recent commit][0] which indicated to me that the passing tests might be OK -- not sure. The tests in question are found in test/notifier.js.

The other thing is, esmock-imported modules are each using their own state, so tests could be updated in the future to run concurrently rather [than sequentially (here).][1] 


[0]: https://github.com/yeoman/update-notifier/commit/91835415ca721fd4a87a9f822ce9a6c3a377c8d1
[1]: https://github.com/yeoman/update-notifier/blob/main/package.json#L65