### PR TITLE
chore: upgrade deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"is-in-ci": "^0.1.0",
 		"is-installed-globally": "^0.4.0",
 		"is-npm": "^6.0.0",
-		"latest-version": "^7.0.0",
+		"latest-version": "^9.0.0",
 		"pupa": "^3.1.0",
 		"semver": "^7.5.4",
 		"semver-diff": "^4.0.0",


### PR DESCRIPTION
Update deps to fix the Dependabot alerts

Got allows a redirect to a UNIX socket #62

CVE ID

CVE-2022-33987

deps map:
- update-notifier
- latest-version
- package-json
- got