### PR TITLE
Drop redundant dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
 		"latest-version": "^9.0.0",
 		"pupa": "^3.1.0",
 		"semver": "^7.6.3",
-		"semver-diff": "^4.0.0",
 		"xdg-basedir": "^5.1.0"
 	},
 	"devDependencies": {

--- a/update-notifier.js
+++ b/update-notifier.js
@@ -5,8 +5,9 @@ import path from 'node:path';
 import {format} from 'node:util';
 import ConfigStore from 'configstore';
 import chalk from 'chalk';
-import semverDiff from 'semver/functions/diff';
-import semverGt from 'semver/functions/gt';
+// Only import what we need for performance
+import semverDiff from 'semver/functions/diff.js';
+import semverGt from 'semver/functions/gt.js';
 import latestVersion from 'latest-version';
 import {isNpmOrYarn} from 'is-npm';
 import isInstalledGlobally from 'is-installed-globally';

--- a/update-notifier.js
+++ b/update-notifier.js
@@ -5,8 +5,8 @@ import path from 'node:path';
 import {format} from 'node:util';
 import ConfigStore from 'configstore';
 import chalk from 'chalk';
-import semver from 'semver';
-import semverDiff from 'semver-diff';
+import semverDiff from 'semver/functions/diff';
+import semverGt from 'semver/functions/gt'
 import latestVersion from 'latest-version';
 import {isNpmOrYarn} from 'is-npm';
 import isInstalledGlobally from 'is-installed-globally';
@@ -126,7 +126,7 @@ export default class UpdateNotifier {
 
 	notify(options) {
 		const suppressForNpm = !this._shouldNotifyInNpmScript && isNpmOrYarn;
-		if (!process.stdout.isTTY || suppressForNpm || !this.update || !semver.gt(this.update.latest, this.update.current)) {
+		if (!process.stdout.isTTY || suppressForNpm || !this.update || !semverGt(this.update.latest, this.update.current)) {
 			return this;
 		}
 

--- a/update-notifier.js
+++ b/update-notifier.js
@@ -6,7 +6,7 @@ import {format} from 'node:util';
 import ConfigStore from 'configstore';
 import chalk from 'chalk';
 import semverDiff from 'semver/functions/diff';
-import semverGt from 'semver/functions/gt'
+import semverGt from 'semver/functions/gt';
 import latestVersion from 'latest-version';
 import {isNpmOrYarn} from 'is-npm';
 import isInstalledGlobally from 'is-installed-globally';


### PR DESCRIPTION
It looks like this initially used semver-diff, but then loaded the whole of semver, making the former redundant.

This PR drops semver-diff and avoids the [`index` file](https://x.com/iamakulov/status/1331551351214645251) import from semver.