### PR TITLE
feat: add custom printFn to options

### DIFF
--- a/update-notifier.js
+++ b/update-notifier.js
@@ -38,6 +38,7 @@ export default class UpdateNotifier {
 		this.#options = options;
 		options.pkg ??= {};
 		options.distTag ??= 'latest';
+		options.printFn ??= console.error;
 
 		// Reduce pkg to the essential keys. with fallback to deprecated options
 		// TODO: Remove deprecated options at some point far into the future
@@ -76,7 +77,7 @@ export default class UpdateNotifier {
 					+ chalk.cyan(format(' sudo chown -R $USER:$(id -gn $USER) %s ', xdgConfig));
 
 				process.on('exit', () => {
-					console.error(boxen(message, {textAlignment: 'center'}));
+					options.printFn(boxen(message, {textAlignment: 'center'}));
 				});
 			}
 		}
@@ -165,10 +166,10 @@ export default class UpdateNotifier {
 		);
 
 		if (options.defer === false) {
-			console.error(message);
+			options.printFn(message);
 		} else {
 			process.on('exit', () => {
-				console.error(message);
+				options.printFn(message);
 			});
 		}
 


### PR DESCRIPTION
Hey, thanks for the great library.

In some cases as [ours](https://github.com/upstreetAI/upstreet-core), we may not want unnecessary `console.error`s as we use them to write to a special error log.

We don't consider an older version an "error", we consider it "info"-level logging category.

I'm not sure how to add types in this repo, if anyone could guide I'd appreciate it.